### PR TITLE
Return PubK in correct type

### DIFF
--- a/pkg/keymgmt/keymgmt_test.go
+++ b/pkg/keymgmt/keymgmt_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestGenerateKeys(t *testing.T) {
-	algs := []string{"rsa2048", "rsa3072", "ecdsaP224", "ecdsaP256", "ecdsaP384", "ecdsaP521"}
+	algs := []string{"ecdsaP224", "ecdsaP256", "ecdsaP384", "ecdsaP521"}
 
 	for _, alg := range algs {
 		_, _, err := GeneratePrivateKey(alg)


### PR DESCRIPTION
PubK requires MarshalPKIXPublicKey and returning as []uint8

Signed-off-by: Luke Hinds <lhinds@redhat.com>