### PR TITLE
Use `crypto.PublicKey` in favor of `*ecdsa.PublicKey`

### DIFF
--- a/pkg/keymgmt/keymgmt.go
+++ b/pkg/keymgmt/keymgmt.go
@@ -16,6 +16,7 @@ limitations under the License.
 package keymgmt
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -23,7 +24,7 @@ import (
 	"errors"
 )
 
-func GeneratePrivateKey(algorithm string) (interface{}, interface{}, error) {
+func GeneratePrivateKey(algorithm string) (interface{}, crypto.PublicKey, error) {
 	var err error
 	var key interface{}
 	// Allow algorithm agility if different projects have certain FIPS like compliance requirements
@@ -43,7 +44,7 @@ func GeneratePrivateKey(algorithm string) (interface{}, interface{}, error) {
 		return nil, nil, err
 	}
 
-	pub, err := getPublicKeyBytes(key)
+	pub, err := getPublicKey(key)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -51,7 +52,7 @@ func GeneratePrivateKey(algorithm string) (interface{}, interface{}, error) {
 	return key, pub, err
 }
 
-func getPublicKeyBytes(priv interface{}) (interface{}, error) {
+func getPublicKey(priv interface{}) (crypto.PublicKey, error) {
 	var err error
 	var pub interface{}
 	switch k := priv.(type) {
@@ -60,7 +61,7 @@ func getPublicKeyBytes(priv interface{}) (interface{}, error) {
 	case *ecdsa.PrivateKey:
 		pub = &k.PublicKey
 	default:
-		err = errors.New("error generating public key" )
+		err = errors.New("error generating public key")
 	}
 	if err != nil {
 		panic("error creating pubkey")
@@ -68,4 +69,3 @@ func getPublicKeyBytes(priv interface{}) (interface{}, error) {
 
 	return pub, err
 }
-

--- a/pkg/signfile/signfile.go
+++ b/pkg/signfile/signfile.go
@@ -1,14 +1,15 @@
 package signfile
 
 import (
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"strconv"
+
 	"github.com/go-openapi/swag"
 	"github.com/pkg/errors"
-	"strconv"
 
 	"github.com/sigstore/rekor/cmd/cli/app"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
@@ -23,7 +24,7 @@ type SignedPayload struct {
 	Chain           []*x509.Certificate
 }
 
-func UploadToRekor(publicKey *ecdsa.PublicKey, digest []byte, signedMsg []byte, rekorUrl string, certPEM []byte, payload []byte) (string, error) {
+func UploadToRekor(publicKey crypto.PublicKey, digest []byte, signedMsg []byte, rekorUrl string, certPEM []byte, payload []byte) (string, error) {
 	rekorClient, err := app.GetRekorClient(rekorUrl)
 	if err != nil {
 		return "", err
@@ -64,7 +65,7 @@ func UploadToRekor(publicKey *ecdsa.PublicKey, digest []byte, signedMsg []byte, 
 	return "", errors.New("bad response from server")
 }
 
-func MarshalPublicKey(pub *ecdsa.PublicKey) ([]byte, error) {
+func MarshalPublicKey(pub crypto.PublicKey) ([]byte, error) {
 	if pub == nil {
 		return nil, errors.New("empty key")
 	}


### PR DESCRIPTION
Signed-off-by: Jake Sanders <jsand@google.com>
