### PR TITLE
Add support for ed25519 based keys

### DIFF
--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -1,0 +1,71 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	_ "crypto/sha256" // To ensure `crypto.SHA256` is implemented.
+	"errors"
+	"fmt"
+)
+
+type ED25519Verifier struct {
+	Key ed25519.PublicKey
+}
+
+type ED25519SignerVerifier struct {
+	ED25519Verifier
+	Key ed25519.PrivateKey
+}
+
+func (s ED25519SignerVerifier) Sign(_ context.Context, rawPayload []byte) (signature, signed []byte, err error) {
+	signature = ed25519.Sign(s.Key, rawPayload)
+	return
+}
+
+func (v ED25519Verifier) Verify(_ context.Context, rawPayload, signature []byte) error {
+	if !ed25519.Verify(v.Key, rawPayload, signature) {
+		return errors.New("unable to verify signature")
+	}
+	return nil
+}
+
+func (k ED25519Verifier) PublicKey(_ context.Context) (crypto.PublicKey, error) {
+	return k.Key, nil
+}
+
+var _ SignerVerifier = ECDSASignerVerifier{}
+var _ Verifier = ECDSAVerifier{}
+
+func NewED25519SignerVerifier(pubKey ed25519.PublicKey, privKey ed25519.PrivateKey) ED25519SignerVerifier {
+	return ED25519SignerVerifier{
+		ED25519Verifier: ED25519Verifier{
+			Key: pubKey,
+		},
+		Key: privKey,
+	}
+}
+
+func NewDefaultED25519SignerVerifier() (ED25519SignerVerifier, error) {
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return ED25519SignerVerifier{}, fmt.Errorf("could not generate ed25519 keypair: %v", err)
+	}
+	return NewED25519SignerVerifier(pubKey, privKey), nil
+}

--- a/pkg/signature/ed25519_test.go
+++ b/pkg/signature/ed25519_test.go
@@ -1,0 +1,32 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import "testing"
+
+func newTestED25519SignerVerifier(t *testing.T) ED25519SignerVerifier {
+	t.Helper()
+	sv, err := NewDefaultED25519SignerVerifier()
+	if err != nil {
+		t.Fatalf("NewDefaultED25519SignerVerifier() failed with error: %v", err)
+	}
+	return sv
+}
+
+func TestDefaultED25519SignerVerifier(t *testing.T) {
+	sv := newTestED25519SignerVerifier(t)
+	smokeTestSignerVerifier(t, sv)
+}


### PR DESCRIPTION
We can use this in tekton chains! 

Signed-off-by: Priya Wadhwa <priyawadhwa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
