### PR TITLE
remove gosec since it is handled by golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,13 +58,6 @@ jobs:
         skip-go-installation: true
         skip-pkg-cache: true
 
-    - name: Run Gosec Security Scanner
-      uses: securego/gosec@v2.7.0
-      env:
-        GOROOT: ""
-      with:
-        args: ./...
-
     - name: Ensure no files were modified as a result of the build
       run: git update-index --refresh && git diff-index --quiet HEAD -- || git diff
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+linters:
+  enable:
+  - deadcode
+  - errcheck
+  - gofmt
+  - goimports
+  - gosec
+  - gocritic
+  - golint
+  - misspell
+output:
+  uniq-by-line: false
+issues:
+  exclude-rules:
+  - path: _test\.go
+    linters:
+    - errcheck
+    - gosec
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  issues-exit-code: 1
+  timeout: 10m

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all test clean lint gosec
+.PHONY: all test clean lint
 
 all: client
 
@@ -45,9 +45,6 @@ $(GENSRC):
 lint:
 	$(GOBIN)/golangci-lint run -v ./...
 
-gosec:
-	$(GOBIN)/gosec ./...
-
 client: $(SRCS)
 	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o sigstore
 
@@ -60,10 +57,3 @@ test-e2e:
 clean:
 	rm -rf sigstore
 
-#up:
-	#docker-compose -f docker-compose.yml build
-	#docker-compose -f docker-compose.yml up
-
-#debug:
-	#docker-compose -f docker-compose.yml -f docker-compose.debug.yml build fulcio-server-debug
-	#docker-compose -f docker-compose.yml -f docker-compose.debug.yml up fulcio-server-debug

--- a/pkg/kms/kms.go
+++ b/pkg/kms/kms.go
@@ -52,23 +52,23 @@ type KMS interface {
 
 type ProviderInit func(context.Context, string) (KMS, error)
 
-type KMSProviders struct {
+type Providers struct {
 	providers map[string]ProviderInit
 }
 
-func (p *KMSProviders) AddProvider(keyResourceID string, init ProviderInit) {
+func (p *Providers) AddProvider(keyResourceID string, init ProviderInit) {
 	p.providers[keyResourceID] = init
 }
 
-func (p *KMSProviders) Providers() map[string]ProviderInit {
+func (p *Providers) Providers() map[string]ProviderInit {
 	return p.providers
 }
 
-var providersMux = &KMSProviders{
+var providersMux = &Providers{
 	providers: map[string]ProviderInit{},
 }
 
-func ProvidersMux() *KMSProviders {
+func ProvidersMux() *Providers {
 	return providersMux
 }
 
@@ -78,5 +78,5 @@ func Get(ctx context.Context, keyResourceID string) (KMS, error) {
 			return providerInit(ctx, keyResourceID)
 		}
 	}
-	return nil, fmt.Errorf("No provider found for that key reference")
+	return nil, fmt.Errorf("no provider found for that key reference")
 }

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -38,8 +38,8 @@ const (
 type deviceResp struct {
 	DeviceCode              string `json:"device_code"`
 	UserCode                string `json:"user_code"`
-	VerificationUri         string `json:"verification_uri"`
-	VerificationUriComplete string `json:"verification_uri_complete"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
 	Interval                int    `json:"interval"`
 	ExpiresIn               int    `json:"expires_in"`
 }
@@ -87,9 +87,9 @@ func (d *DeviceFlowTokenGetter) deviceFlow(clientID string) (string, error) {
 	if err := json.Unmarshal(b, &parsed); err != nil {
 		return "", err
 	}
-	uri := parsed.VerificationUriComplete
+	uri := parsed.VerificationURIComplete
 	if uri == "" {
-		uri = parsed.VerificationUri
+		uri = parsed.VerificationURI
 	}
 	d.MessagePrinter(fmt.Sprintf("Enter the verification code %s in your browser at: %s", parsed.UserCode, uri))
 	d.MessagePrinter(fmt.Sprintf("Code will be valid for %d seconds", parsed.ExpiresIn))
@@ -146,7 +146,7 @@ func (d *DeviceFlowTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) 
 		return nil, err
 	}
 
-	if _, err := emailFromIdToken(parsedIDToken); err != nil {
+	if _, err := emailFromIDToken(parsedIDToken); err != nil {
 		return nil, err
 	}
 

--- a/pkg/oauthflow/device_test.go
+++ b/pkg/oauthflow/device_test.go
@@ -100,7 +100,7 @@ func codeResponse() deviceResp {
 		UserCode:                "mysecret",
 		DeviceCode:              "foobar",
 		Interval:                3,
-		VerificationUriComplete: "complete-uri",
+		VerificationURIComplete: "complete-uri",
 	}
 }
 

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -68,14 +68,14 @@ func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCI
 		return nil, "", err
 	}
 
-	email, err := emailFromIdToken(idToken.ParsedToken)
+	email, err := emailFromIDToken(idToken.ParsedToken)
 	if err != nil {
 		return nil, "", err
 	}
 	return idToken, email, nil
 }
 
-func emailFromIdToken(tok *oidc.IDToken) (string, error) {
+func emailFromIDToken(tok *oidc.IDToken) (string, error) {
 	var claims struct {
 		Email    string `json:"email"`
 		Verified bool   `json:"email_verified"`

--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -60,8 +60,8 @@ func (v ECDSAVerifier) Verify(_ context.Context, rawPayload, signature []byte) e
 	return nil
 }
 
-func (k ECDSAVerifier) PublicKey(_ context.Context) (crypto.PublicKey, error) {
-	return k.Key, nil
+func (v ECDSAVerifier) PublicKey(_ context.Context) (crypto.PublicKey, error) {
+	return v.Key, nil
 }
 
 var _ SignerVerifier = ECDSASignerVerifier{}

--- a/pkg/signfile/signfile.go
+++ b/pkg/signfile/signfile.go
@@ -39,8 +39,8 @@ type SignedPayload struct {
 	Chain           []*x509.Certificate
 }
 
-func UploadToRekor(publicKey crypto.PublicKey, digest []byte, signedMsg []byte, rekorUrl string, certPEM []byte, payload []byte) (string, error) {
-	rekorClient, err := app.GetRekorClient(rekorUrl)
+func UploadToRekor(publicKey crypto.PublicKey, digest []byte, signedMsg []byte, rekorURL string, certPEM []byte, payload []byte) (string, error) {
+	rekorClient, err := app.GetRekorClient(rekorURL)
 	if err != nil {
 		return "", err
 	}
@@ -65,7 +65,7 @@ func UploadToRekor(publicKey crypto.PublicKey, digest []byte, signedMsg []byte, 
 		if _, ok := err.(*entries.CreateLogEntryConflict); ok {
 			cs := SignedPayload{
 				Base64Signature: base64.StdEncoding.EncodeToString(signedMsg),
-				Payload:         digest[:],
+				Payload:         digest,
 			}
 			fmt.Println("Signature already exists. Displaying proof")
 


### PR DESCRIPTION
Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
