### PR TITLE
Add support for static identity tokens supplied directly by the caller.

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -65,7 +65,7 @@ var signCmd = &cobra.Command{
 		}
 
 		// Retrieve idToken from oidc provider
-		idToken, email, err := oauthflow.OIDConnect(
+		idToken, err := oauthflow.OIDConnect(
 			viper.GetString("oidc-issuer"),
 			viper.GetString("oidc-client-id"),
 			viper.GetString("oidc-client-secret"),
@@ -74,7 +74,7 @@ var signCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println("\nReceived OpenID Scope retrieved for account:", email)
+		fmt.Println("\nReceived OpenID Scope retrieved for account:", idToken.Email)
 
 		signer, err := signature.NewDefaultECDSASignerVerifier()
 		if err != nil {
@@ -90,7 +90,7 @@ var signCmd = &cobra.Command{
 			return err
 		}
 
-		proof, _, err := signer.Sign(ctx, []byte(email))
+		proof, _, err := signer.Sign(ctx, []byte(idToken.Email))
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,5 @@ require (
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1
 	google.golang.org/protobuf v1.26.0
+	gopkg.in/square/go-jose.v2 v2.5.1
 )

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -135,7 +135,6 @@ func (d *DeviceFlowTokenGetter) deviceFlow(clientID string) (string, error) {
 }
 
 func (d *DeviceFlowTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) (*OIDCIDToken, error) {
-
 	idToken, err := d.deviceFlow(cfg.ClientID)
 	if err != nil {
 		return nil, err
@@ -146,12 +145,13 @@ func (d *DeviceFlowTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) 
 		return nil, err
 	}
 
-	if _, err := emailFromIDToken(parsedIDToken); err != nil {
+	email, err := emailFromIDToken(parsedIDToken)
+	if err != nil {
 		return nil, err
 	}
 
 	return &OIDCIDToken{
-		RawString:   idToken,
-		ParsedToken: parsedIDToken,
+		RawString: idToken,
+		Email:     email,
 	}, nil
 }

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -90,9 +90,14 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 		}
 	}
 
+	email, err := emailFromIDToken(parsedIDToken)
+	if err != nil {
+		return nil, err
+	}
+
 	returnToken := OIDCIDToken{
-		RawString:   idToken,
-		ParsedToken: parsedIDToken,
+		RawString: idToken,
+		Email:     email,
 	}
 	return &returnToken, nil
 }

--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -34,13 +34,13 @@ type ED25519SignerVerifier struct {
 	Key ed25519.PrivateKey
 }
 
-func (s ED25519SignerVerifier) Sign(_ context.Context, rawPayload []byte) (signature, signed []byte, err error) {
-	signature = ed25519.Sign(s.Key, rawPayload)
+func (k ED25519SignerVerifier) Sign(_ context.Context, rawPayload []byte) (signature, signed []byte, err error) {
+	signature = ed25519.Sign(k.Key, rawPayload)
 	return
 }
 
-func (v ED25519Verifier) Verify(_ context.Context, rawPayload, signature []byte) error {
-	if !ed25519.Verify(v.Key, rawPayload, signature) {
+func (k ED25519Verifier) Verify(_ context.Context, rawPayload, signature []byte) error {
+	if !ed25519.Verify(k.Key, rawPayload, signature) {
 		return errors.New("unable to verify signature")
 	}
 	return nil


### PR DESCRIPTION
This is part of the federation/SPIRE/keyless flows for machines.

Signed-off-by: Dan Lorenc <dlorenc@google.com>