### PR TITLE
Refactor IDToken handling to support claims based on fields other tha…

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -74,7 +74,7 @@ var signCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println("\nReceived OpenID Scope retrieved for account:", idToken.Email)
+		fmt.Println("\nReceived OpenID Scope retrieved for account:", idToken.Subject)
 
 		signer, err := signature.NewDefaultECDSASignerVerifier()
 		if err != nil {
@@ -92,7 +92,7 @@ var signCmd = &cobra.Command{
 			return err
 		}
 
-		proof, _, err := signer.Sign(ctx, []byte(idToken.Email))
+		proof, _, err := signer.Sign(ctx, []byte(idToken.Subject))
 		if err != nil {
 			return err
 		}

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -145,13 +145,13 @@ func (d *DeviceFlowTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) 
 		return nil, err
 	}
 
-	email, err := emailFromIDToken(parsedIDToken)
+	subj, err := SubjectFromToken(parsedIDToken)
 	if err != nil {
 		return nil, err
 	}
 
 	return &OIDCIDToken{
 		RawString: idToken,
-		Email:     email,
+		Subject:   subj,
 	}, nil
 }

--- a/pkg/oauthflow/flow_test.go
+++ b/pkg/oauthflow/flow_test.go
@@ -136,7 +136,16 @@ func TestStaticTokenGetter_GetIDToken(t *testing.T) {
 				Verified: true,
 			},
 			want: &OIDCIDToken{
-				Email: "foobar",
+				Subject: "foobar",
+			},
+		},
+		{
+			name: "spiffeid",
+			payload: claims{
+				Subject: "spiffe://foobar",
+			},
+			want: &OIDCIDToken{
+				Subject: "spiffe://foobar",
 			},
 		},
 	}

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -90,14 +90,14 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 		}
 	}
 
-	email, err := emailFromIDToken(parsedIDToken)
+	email, err := SubjectFromToken(parsedIDToken)
 	if err != nil {
 		return nil, err
 	}
 
 	returnToken := OIDCIDToken{
 		RawString: idToken,
-		Email:     email,
+		Subject:   email,
 	}
 	return &returnToken, nil
 }


### PR DESCRIPTION
…n email.

This allows us to start issuing certs based on SPIFFE IDs.

Signed-off-by: Dan Lorenc <dlorenc@google.com>
