### PR TITLE
replace context with Options in Signer, Verifier, and PublicKeyProvider interfaces

### DIFF
--- a/pkg/generated/client/operations/operations_client.go
+++ b/pkg/generated/client/operations/operations_client.go
@@ -39,12 +39,9 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
-type ClientOption func(*runtime.ClientOperation)
-
 // ClientService is the interface for Client methods
 type ClientService interface {
-	SigningCert(params *SigningCertParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*SigningCertCreated, error)
+	SigningCert(params *SigningCertParams, authInfo runtime.ClientAuthInfoWriter) (*SigningCertCreated, error)
 
 	SetTransport(transport runtime.ClientTransport)
 }
@@ -52,12 +49,13 @@ type ClientService interface {
 /*
   SigningCert create a cert, return content with a location header (with URL to CTL entry)
 */
-func (a *Client) SigningCert(params *SigningCertParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*SigningCertCreated, error) {
+func (a *Client) SigningCert(params *SigningCertParams, authInfo runtime.ClientAuthInfoWriter) (*SigningCertCreated, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewSigningCertParams()
 	}
-	op := &runtime.ClientOperation{
+
+	result, err := a.transport.Submit(&runtime.ClientOperation{
 		ID:                 "signingCert",
 		Method:             "POST",
 		PathPattern:        "/signingCert",
@@ -69,12 +67,7 @@ func (a *Client) SigningCert(params *SigningCertParams, authInfo runtime.ClientA
 		AuthInfo:           authInfo,
 		Context:            params.Context,
 		Client:             params.HTTPClient,
-	}
-	for _, opt := range opts {
-		opt(op)
-	}
-
-	result, err := a.transport.Submit(op)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/generated/client/operations/signing_cert_parameters.go
+++ b/pkg/generated/client/operations/signing_cert_parameters.go
@@ -34,73 +34,59 @@ import (
 	"github.com/sigstore/sigstore/pkg/generated/models"
 )
 
-// NewSigningCertParams creates a new SigningCertParams object,
-// with the default timeout for this client.
-//
-// Default values are not hydrated, since defaults are normally applied by the API server side.
-//
-// To enforce default values in parameter, use SetDefaults or WithDefaults.
+// NewSigningCertParams creates a new SigningCertParams object
+// with the default values initialized.
 func NewSigningCertParams() *SigningCertParams {
+	var ()
 	return &SigningCertParams{
+
 		timeout: cr.DefaultTimeout,
 	}
 }
 
 // NewSigningCertParamsWithTimeout creates a new SigningCertParams object
-// with the ability to set a timeout on a request.
+// with the default values initialized, and the ability to set a timeout on a request
 func NewSigningCertParamsWithTimeout(timeout time.Duration) *SigningCertParams {
+	var ()
 	return &SigningCertParams{
+
 		timeout: timeout,
 	}
 }
 
 // NewSigningCertParamsWithContext creates a new SigningCertParams object
-// with the ability to set a context for a request.
+// with the default values initialized, and the ability to set a context for a request
 func NewSigningCertParamsWithContext(ctx context.Context) *SigningCertParams {
+	var ()
 	return &SigningCertParams{
+
 		Context: ctx,
 	}
 }
 
 // NewSigningCertParamsWithHTTPClient creates a new SigningCertParams object
-// with the ability to set a custom HTTPClient for a request.
+// with the default values initialized, and the ability to set a custom HTTPClient for a request
 func NewSigningCertParamsWithHTTPClient(client *http.Client) *SigningCertParams {
+	var ()
 	return &SigningCertParams{
 		HTTPClient: client,
 	}
 }
 
-/* SigningCertParams contains all the parameters to send to the API endpoint
-   for the signing cert operation.
-
-   Typically these are written to a http.Request.
+/*SigningCertParams contains all the parameters to send to the API endpoint
+for the signing cert operation typically these are written to a http.Request
 */
 type SigningCertParams struct {
 
-	/* CertificateRequest.
+	/*CertificateRequest
+	  Request for signing certificate
 
-	   Request for signing certificate
 	*/
 	CertificateRequest *models.CertificateRequest
 
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
-}
-
-// WithDefaults hydrates default values in the signing cert params (not the query body).
-//
-// All values with no default are reset to their zero value.
-func (o *SigningCertParams) WithDefaults() *SigningCertParams {
-	o.SetDefaults()
-	return o
-}
-
-// SetDefaults hydrates default values in the signing cert params (not the query body).
-//
-// All values with no default are reset to their zero value.
-func (o *SigningCertParams) SetDefaults() {
-	// no default values defined for this parameter
 }
 
 // WithTimeout adds the timeout to the signing cert params
@@ -154,6 +140,7 @@ func (o *SigningCertParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.R
 		return err
 	}
 	var res []error
+
 	if o.CertificateRequest != nil {
 		if err := r.SetBodyParam(o.CertificateRequest); err != nil {
 			return err

--- a/pkg/generated/client/operations/signing_cert_responses.go
+++ b/pkg/generated/client/operations/signing_cert_responses.go
@@ -74,7 +74,7 @@ func NewSigningCertCreated() *SigningCertCreated {
 	return &SigningCertCreated{}
 }
 
-/* SigningCertCreated describes a response with status code 201, with default header values.
+/*SigningCertCreated handles this case with default header values.
 
 Generated Certificate Chain
 */
@@ -85,6 +85,7 @@ type SigningCertCreated struct {
 func (o *SigningCertCreated) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCertCreated  %+v", 201, o.Payload)
 }
+
 func (o *SigningCertCreated) GetPayload() string {
 	return o.Payload
 }
@@ -104,7 +105,7 @@ func NewSigningCertBadRequest() *SigningCertBadRequest {
 	return &SigningCertBadRequest{}
 }
 
-/* SigningCertBadRequest describes a response with status code 400, with default header values.
+/*SigningCertBadRequest handles this case with default header values.
 
 The content supplied to the server was invalid
 */
@@ -117,18 +118,15 @@ type SigningCertBadRequest struct {
 func (o *SigningCertBadRequest) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCertBadRequest  %+v", 400, o.Payload)
 }
+
 func (o *SigningCertBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
 func (o *SigningCertBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// hydrates response header Content-Type
-	hdrContentType := response.GetHeader("Content-Type")
-
-	if hdrContentType != "" {
-		o.ContentType = hdrContentType
-	}
+	// response header Content-Type
+	o.ContentType = response.GetHeader("Content-Type")
 
 	o.Payload = new(models.Error)
 
@@ -145,14 +143,13 @@ func NewSigningCertUnauthorized() *SigningCertUnauthorized {
 	return &SigningCertUnauthorized{}
 }
 
-/* SigningCertUnauthorized describes a response with status code 401, with default header values.
+/*SigningCertUnauthorized handles this case with default header values.
 
 The request could not be authorized
 */
 type SigningCertUnauthorized struct {
 	ContentType string
-
-	/* Information about required authentication to access server
+	/*Information about required authentication to access server
 	 */
 	WWWAuthenticate string
 
@@ -162,25 +159,18 @@ type SigningCertUnauthorized struct {
 func (o *SigningCertUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCertUnauthorized  %+v", 401, o.Payload)
 }
+
 func (o *SigningCertUnauthorized) GetPayload() *models.Error {
 	return o.Payload
 }
 
 func (o *SigningCertUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// hydrates response header Content-Type
-	hdrContentType := response.GetHeader("Content-Type")
+	// response header Content-Type
+	o.ContentType = response.GetHeader("Content-Type")
 
-	if hdrContentType != "" {
-		o.ContentType = hdrContentType
-	}
-
-	// hydrates response header WWW-Authenticate
-	hdrWWWAuthenticate := response.GetHeader("WWW-Authenticate")
-
-	if hdrWWWAuthenticate != "" {
-		o.WWWAuthenticate = hdrWWWAuthenticate
-	}
+	// response header WWW-Authenticate
+	o.WWWAuthenticate = response.GetHeader("WWW-Authenticate")
 
 	o.Payload = new(models.Error)
 
@@ -199,12 +189,13 @@ func NewSigningCertDefault(code int) *SigningCertDefault {
 	}
 }
 
-/* SigningCertDefault describes a response with status code -1, with default header values.
+/*SigningCertDefault handles this case with default header values.
 
 There was an internal error in the server while processing the request
 */
 type SigningCertDefault struct {
 	_statusCode int
+
 	ContentType string
 
 	Payload *models.Error
@@ -218,18 +209,15 @@ func (o *SigningCertDefault) Code() int {
 func (o *SigningCertDefault) Error() string {
 	return fmt.Sprintf("[POST /signingCert][%d] signingCert default  %+v", o._statusCode, o.Payload)
 }
+
 func (o *SigningCertDefault) GetPayload() *models.Error {
 	return o.Payload
 }
 
 func (o *SigningCertDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	// hydrates response header Content-Type
-	hdrContentType := response.GetHeader("Content-Type")
-
-	if hdrContentType != "" {
-		o.ContentType = hdrContentType
-	}
+	// response header Content-Type
+	o.ContentType = response.GetHeader("Content-Type")
 
 	o.Payload = new(models.Error)
 

--- a/pkg/generated/models/certificate_request.go
+++ b/pkg/generated/models/certificate_request.go
@@ -22,7 +22,6 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
 	"encoding/json"
 
 	"github.com/go-openapi/errors"
@@ -86,34 +85,6 @@ func (m *CertificateRequest) validateSignedEmailAddress(formats strfmt.Registry)
 
 	if err := validate.Required("signedEmailAddress", "body", m.SignedEmailAddress); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-// ContextValidate validate this certificate request based on the context it is used
-func (m *CertificateRequest) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.contextValidatePublicKey(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *CertificateRequest) contextValidatePublicKey(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.PublicKey != nil {
-		if err := m.PublicKey.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("publicKey")
-			}
-			return err
-		}
 	}
 
 	return nil
@@ -197,6 +168,7 @@ func (m *CertificateRequestPublicKey) validateAlgorithmEnum(path, location strin
 }
 
 func (m *CertificateRequestPublicKey) validateAlgorithm(formats strfmt.Registry) error {
+
 	if swag.IsZero(m.Algorithm) { // not required
 		return nil
 	}
@@ -215,11 +187,6 @@ func (m *CertificateRequestPublicKey) validateContent(formats strfmt.Registry) e
 		return err
 	}
 
-	return nil
-}
-
-// ContextValidate validates this certificate request public key based on context it is used
-func (m *CertificateRequestPublicKey) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/generated/models/error.go
+++ b/pkg/generated/models/error.go
@@ -22,8 +22,6 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"context"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
@@ -42,11 +40,6 @@ type Error struct {
 
 // Validate validates this error
 func (m *Error) Validate(formats strfmt.Registry) error {
-	return nil
-}
-
-// ContextValidate validates this error based on context it is used
-func (m *Error) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }
 

--- a/pkg/signature/adapter.go
+++ b/pkg/signature/adapter.go
@@ -1,0 +1,45 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"context"
+	"crypto"
+	"io"
+
+	"github.com/sigstore/sigstore/pkg/signature/option"
+)
+
+type cryptoSignerAdapter struct {
+	Signer
+	ctx                   context.Context
+	publicKeyErrorHandler func(error)
+}
+
+func (sa cryptoSignerAdapter) Public() crypto.PublicKey {
+	pk, err := sa.PublicKey(option.WithContext(sa.ctx))
+	if err != nil && sa.publicKeyErrorHandler != nil {
+		sa.publicKeyErrorHandler(err)
+	}
+	return pk
+}
+
+func (sa cryptoSignerAdapter) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	return sa.Signer.Sign(nil, option.WithContext(sa.ctx), option.WithMessageDigest(digest, opts.HashFunc()), option.WithRand(rand))
+}
+
+func CryptoSigner(ctx context.Context, signer Signer, pkErrorHandler func(error)) crypto.Signer {
+	return cryptoSignerAdapter{Signer: signer, ctx: ctx, publicKeyErrorHandler: pkErrorHandler}
+}

--- a/pkg/signature/option/context.go
+++ b/pkg/signature/option/context.go
@@ -1,0 +1,33 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import "context"
+
+// RequestContext is an option which designates a request context, as required by some Signer, Verifier, or PublicKeyProvider implementations.
+type RequestContext struct {
+	NoOpOptionImpl
+	ctx context.Context
+}
+
+// ApplyContext sets the specified Context, implementing the RPCOption interface.
+func (c RequestContext) ApplyContext(ctx *context.Context) {
+	*ctx = c.ctx
+}
+
+// WithContext returns an option which designates the request context.
+func WithContext(ctx context.Context) RequestContext {
+	return RequestContext{ctx: ctx}
+}

--- a/pkg/signature/option/digest.go
+++ b/pkg/signature/option/digest.go
@@ -1,0 +1,44 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import "crypto"
+
+// MessageDigest is an option used to declare that the message passed to Sign or Verify is already in a processed state, and can be directly signed or verified against a signature.
+type MessageDigest struct {
+	NoOpOptionImpl
+	digest     []byte
+	cryptoOpts crypto.SignerOpts
+}
+
+// ApplyDigest provides an explicit `digest` to sign or verify a signature against.
+func (m MessageDigest) ApplyDigest(digest *[]byte) {
+	*digest = m.digest
+}
+
+// ApplyCryptoSignerOpts explicitly declares the `opts` passed to `crypto.Signer.Sign()`.
+func (m MessageDigest) ApplyCryptoSignerOpts(cryptoOpts *crypto.SignerOpts) {
+	*cryptoOpts = m.cryptoOpts
+}
+
+// ApplyCryptoSignerOpts explicitly declares the `opts` passed to `crypto.Signer.Sign()`.
+func (m MessageDigest) ApplyHashAlg(hash *crypto.Hash) {
+	*hash = m.cryptoOpts.HashFunc()
+}
+
+// WithMessageDigest declares that signatures should be created or verified against an explicit digest, created by the alg specified in `cryptoOpts`.
+func WithMessageDigest(digest []byte, cryptoOpts crypto.SignerOpts) MessageDigest {
+	return MessageDigest{digest: digest, cryptoOpts: cryptoOpts}
+}

--- a/pkg/signature/option/options.go
+++ b/pkg/signature/option/options.go
@@ -1,0 +1,29 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import (
+	"context"
+	"crypto"
+	"io"
+)
+
+// NoOpOptionImpl implements the RPCOption, SignOption, VerifyOption interfaces as no-ops.
+type NoOpOptionImpl struct{}
+
+func (NoOpOptionImpl) ApplyContext(ctx *context.Context)                   {}
+func (NoOpOptionImpl) ApplyDigest(digest *[]byte)                          {}
+func (NoOpOptionImpl) ApplyCryptoSignerOpts(cryptoOpts *crypto.SignerOpts) {}
+func (NoOpOptionImpl) ApplyRand(rand *io.Reader)                           {}

--- a/pkg/signature/option/rand.go
+++ b/pkg/signature/option/rand.go
@@ -1,0 +1,32 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package option
+
+import "io"
+
+type Rand struct {
+	NoOpOptionImpl
+	rand io.Reader
+}
+
+// ApplyDigest provides an explicit `digest` to sign or verify a signature against.
+func (r Rand) ApplyRand(rand *io.Reader) {
+	*rand = r.rand
+}
+
+// WithRand declares that signatures should be created or verified against an explicit digest, created by the alg specified in `cryptoOpts`.
+func WithRand(rand io.Reader) Rand {
+	return Rand{rand: rand}
+}

--- a/pkg/signature/signer.go
+++ b/pkg/signature/signer.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,26 +15,29 @@
 package signature
 
 import (
-	"context"
 	"crypto"
+	"io"
 )
 
-type PublicKeyProvider interface {
-	PublicKey(context.Context) (crypto.PublicKey, error)
+type PublicKeyOption interface {
+	RPCOption
 }
 
-type Verifier interface {
-	Verify(ctx context.Context, rawPayload, signature []byte) error
+type PublicKeyProvider interface {
+	PublicKey(...PublicKeyOption) (crypto.PublicKey, error)
+}
+
+type SignOption interface {
+	PublicKeyOption
+	MessageOption
+
+	// ApplyRand defines the source of randomness for creating a signature.
+	ApplyRand(rand *io.Reader)
 }
 
 type Signer interface {
 	PublicKeyProvider
 
-	// Sign takes a raw payload, potentially creating a derivative (e.g. hashed) payload, and returns the signature as well as the actual payload that was signed.
-	Sign(ctx context.Context, rawPayload []byte) (signature, signed []byte, err error)
-}
-
-type SignerVerifier interface {
-	Signer
-	Verifier
+	// Sign takes a raw message, and returns a `Verify`-able signature for the message.
+	Sign(message io.Reader, signerOpts ...SignOption) (signature []byte, err error)
 }

--- a/pkg/signature/signer_verifier.go
+++ b/pkg/signature/signer_verifier.go
@@ -1,0 +1,37 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"context"
+	"crypto"
+)
+
+type RPCOption interface {
+	// ApplyContext defines the request context for a given signature oprtation, if applicable.
+	ApplyContext(*context.Context)
+}
+
+type MessageOption interface {
+	// ApplyDigest explicitly declares the `digest` to be signed or to verify a signature against.
+	ApplyDigest(digest *[]byte)
+	// ApplyCryptoSignerOpts explicitly declares the `opts` passed to `crypto.Signer.Sign()` and the hash algorithm applied to the input to a signature verification.
+	ApplyCryptoSignerOpts(cryptoOpts *crypto.SignerOpts)
+}
+
+type SignerVerifier interface {
+	Signer
+	Verifier
+}

--- a/pkg/signature/sv_test.go
+++ b/pkg/signature/sv_test.go
@@ -16,16 +16,19 @@
 package signature
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math/rand"
 	"testing"
+
+	"github.com/sigstore/sigstore/pkg/signature/option"
 )
 
 func smokeTestSignerVerifier(t *testing.T, sv SignerVerifier) {
 	t.Helper()
 	ctx := context.Background()
-	pub, err := sv.PublicKey(ctx)
+	pub, err := sv.PublicKey(option.WithContext(ctx))
 	if err != nil {
 		t.Fatalf("PublicKey() failed with error: %v", err)
 	}
@@ -33,14 +36,14 @@ func smokeTestSignerVerifier(t *testing.T, sv SignerVerifier) {
 		t.Fatal("PublicKey() returned nil")
 	}
 	payload := []byte("test payload " + fmt.Sprint(rand.Int()))
-	sig, _, err := sv.Sign(ctx, payload)
+	sig, err := sv.Sign(bytes.NewReader(payload), option.WithContext(ctx))
 	if err != nil {
 		t.Fatalf("Sign() failed with error: %v", err)
 	}
 	if len(sig) == 0 {
 		t.Fatal("Sign() didn't return a signature")
 	}
-	if err := sv.Verify(ctx, payload, sig); err != nil {
+	if err := sv.Verify(bytes.NewReader(payload), sig, option.WithContext(ctx)); err != nil {
 		t.Fatalf("Verify() failed with error: %v", err)
 	}
 }

--- a/pkg/signature/util.go
+++ b/pkg/signature/util.go
@@ -16,33 +16,36 @@
 package signature
 
 import (
-	"context"
+	"bytes"
+	"crypto"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 
 	"github.com/google/go-containerregistry/pkg/name"
 
 	sigpayload "github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-func SignImage(ctx context.Context, signer Signer, image name.Digest, optionalAnnotations map[string]interface{}) (payload, signature, prehashed []byte, err error) {
+func SignImage(signer Signer, image name.Digest, optionalAnnotations map[string]interface{}, opts ...SignOption) (payload, signature []byte, err error) {
 	imgPayload := sigpayload.Cosign{
 		Image:       image,
 		Annotations: optionalAnnotations,
 	}
 	payload, err = json.Marshal(imgPayload)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to marshal payload to JSON: %v", err)
+		return nil, nil, fmt.Errorf("failed to marshal payload to JSON: %v", err)
 	}
-	signature, prehashed, err = signer.Sign(ctx, payload)
+	signature, err = signer.Sign(bytes.NewReader(payload), opts...)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to sign payload: %v", err)
+		return nil, nil, fmt.Errorf("failed to sign payload: %v", err)
 	}
-	return payload, signature, prehashed, nil
+	return payload, signature, nil
 }
 
-func VerifyImageSignature(ctx context.Context, verifier Verifier, payload, signature []byte) (image name.Digest, annotations map[string]interface{}, err error) {
-	if err := verifier.Verify(ctx, payload, signature); err != nil {
+func VerifyImageSignature(verifier Verifier, payload, signature []byte, opts ...VerifyOption) (image name.Digest, annotations map[string]interface{}, err error) {
+	if err := verifier.Verify(bytes.NewReader(payload), signature, opts...); err != nil {
 		return name.Digest{}, nil, fmt.Errorf("signature verification failed: %v", err)
 	}
 	var imgPayload sigpayload.Cosign
@@ -50,4 +53,73 @@ func VerifyImageSignature(ctx context.Context, verifier Verifier, payload, signa
 		return name.Digest{}, nil, fmt.Errorf("could not deserialize image payload: %v", err)
 	}
 	return imgPayload.Image, imgPayload.Annotations, nil
+}
+
+func isSupportedAlg(alg crypto.Hash, supportedAlgs []crypto.Hash) bool {
+	if supportedAlgs == nil {
+		return true
+	}
+	for _, supportedAlg := range supportedAlgs {
+		if alg == supportedAlg {
+			return true
+		}
+	}
+	return false
+}
+
+func MessageToVerify(rawMessage io.Reader, defaultHashAlg crypto.Hash, supportedHashAlgs []crypto.Hash, opts ...VerifyOption) (messageToVerify []byte, hashedWith crypto.Hash, err error) {
+	var cryptoOpts crypto.SignerOpts = defaultHashAlg
+	for _, opt := range opts {
+		opt.ApplyDigest(&messageToVerify)
+		opt.ApplyCryptoSignerOpts(&cryptoOpts)
+	}
+	hashedWith = cryptoOpts.HashFunc()
+	if !isSupportedAlg(hashedWith, supportedHashAlgs) {
+		return nil, crypto.Hash(0), fmt.Errorf("unsupported hash algorithm: %q not in %v", hashedWith.String(), supportedHashAlgs)
+	}
+	if len(messageToVerify) > 0 {
+		return messageToVerify, hashedWith, nil
+	}
+	hash, err := HashedMessage(rawMessage, hashedWith)
+	return hash, hashedWith, err
+}
+
+func MessageToSign(rawMessage io.Reader, defaultHashAlg crypto.Hash, supportedHashAlgs []crypto.Hash, opts ...SignOption) (messageToSign []byte, hashedWith crypto.Hash, err error) {
+	var cryptoOpts crypto.SignerOpts = defaultHashAlg
+	for _, opt := range opts {
+		opt.ApplyDigest(&messageToSign)
+		opt.ApplyCryptoSignerOpts(&cryptoOpts)
+	}
+	hashedWith = cryptoOpts.HashFunc()
+	if !isSupportedAlg(hashedWith, supportedHashAlgs) {
+		return nil, crypto.Hash(0), fmt.Errorf("unsupported hash algorithm: %q not in %v", hashedWith.String(), supportedHashAlgs)
+	}
+	if len(messageToSign) > 0 {
+		return messageToSign, hashedWith, nil
+	}
+	hash, err := HashedMessage(rawMessage, hashedWith)
+	return hash, hashedWith, err
+}
+
+func HashedMessage(rawMessage io.Reader, hashAlg crypto.Hash) (messageToSign []byte, err error) {
+	rawPayload, err := ioutil.ReadAll(rawMessage)
+	if err != nil {
+		return nil, err
+	}
+	if hashAlg == crypto.Hash(0) {
+		return rawPayload, nil
+	}
+	h := hashAlg.New()
+	if _, err := h.Write(rawPayload); err != nil {
+		return nil, fmt.Errorf("failed to create hash: %v", err)
+	}
+	return h.Sum(nil), nil
+}
+
+func GetRand(defaultRandReader io.Reader, opts ...SignOption) io.Reader {
+	randReader := defaultRandReader
+	for _, opt := range opts {
+		opt.ApplyRand(&randReader)
+	}
+	return randReader
 }

--- a/pkg/signature/util_test.go
+++ b/pkg/signature/util_test.go
@@ -16,7 +16,6 @@
 package signature_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -37,7 +36,6 @@ func mustParseDigest(t *testing.T, digestStr string) name.Digest {
 }
 
 func TestProviderRoundtrip(t *testing.T) {
-	ctx := context.Background()
 	ecdsaSV, err := signature.NewDefaultECDSASignerVerifier()
 	if err != nil {
 		t.Fatalf("Could not generate ecdsa SignerVerifier for test: %v", err)
@@ -75,12 +73,12 @@ func TestProviderRoundtrip(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			payload, sig, _, err := signature.SignImage(ctx, tc.sv, tc.digest, tc.claims)
+			payload, sig, err := signature.SignImage(tc.sv, tc.digest, tc.claims)
 			if err != nil {
 				t.Fatalf("SignImage returned error: %v", err)
 			}
 
-			rtDigest, rtClaims, err := signature.VerifyImageSignature(ctx, tc.sv, payload, sig)
+			rtDigest, rtClaims, err := signature.VerifyImageSignature(tc.sv, payload, sig)
 			if err != nil {
 				t.Fatalf("VerifyImageSignature returned error: %v", err)
 			}

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -1,0 +1,28 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"io"
+)
+
+type VerifyOption interface {
+	PublicKeyOption
+	MessageOption
+}
+
+type Verifier interface {
+	Verify(message io.Reader, signature []byte, opts ...VerifyOption) error
+}

--- a/pkg/tlog/tlog.go
+++ b/pkg/tlog/tlog.go
@@ -17,18 +17,11 @@ package tlog
 
 import (
 	"crypto/x509"
-	"encoding/base64"
-	"encoding/hex"
 	"fmt"
-	"strconv"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/google/trillian/merkle/logverifier"
-	"github.com/google/trillian/merkle/rfc6962/hasher"
-	"github.com/pkg/errors"
 	"github.com/sigstore/rekor/cmd/rekor-cli/app"
-	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	rekord_v001 "github.com/sigstore/rekor/pkg/types/rekord/v0.0.1"
@@ -41,8 +34,7 @@ type SignedPayload struct {
 	Chain           []*x509.Certificate
 }
 
-func UploadToRekor(pemBytes []byte, digest []byte, signedMsg []byte, rekorURL string, payload []byte) (string, error) {
-
+func UploadToRekor(pemBytes []byte, signedMsg []byte, rekorURL string, payload []byte) (string, error) {
 	rekorClient, err := app.GetRekorClient(rekorURL)
 	if err != nil {
 		return "", err
@@ -61,82 +53,14 @@ func UploadToRekor(pemBytes []byte, digest []byte, signedMsg []byte, rekorURL st
 	if err != nil {
 		// If the entry already exists, we get a specific error.
 		// Here, we display the proof and succeed.
-		if _, ok := err.(*entries.CreateLogEntryConflict); ok {
-			cs := SignedPayload{
-				Base64Signature: base64.StdEncoding.EncodeToString(signedMsg),
-				Payload:         digest,
-			}
-			fmt.Println("Signature already exists. Displaying proof")
+		if e, ok := err.(*entries.CreateLogEntryConflict); ok {
+			fmt.Printf("Signature already exists at %v\n", e.Location.String())
 
-			return findTlogEntry(rekorClient, cs.Base64Signature, cs.Payload, pemBytes)
+			return e.Location.String(), nil
 		}
 		return "", err
 	}
-	// UUID is at the end of location
-	for _, p := range resp.Payload {
-		return strconv.FormatInt(*p.LogIndex, 10), nil
-	}
-	return "", errors.New("bad response from server")
-}
-
-func findTlogEntry(rekorClient *client.Rekor, b64Sig string, payload, pubKey []byte) (string, error) {
-	searchParams := entries.NewSearchLogQueryParams()
-	searchLogQuery := models.SearchLogQuery{}
-	signature, err := base64.StdEncoding.DecodeString(b64Sig)
-	if err != nil {
-		return "", errors.Wrap(err, "decoding base64 signature")
-	}
-	re := rekorEntry(payload, signature, pubKey)
-	entry := &models.Rekord{
-		APIVersion: swag.String(re.APIVersion()),
-		Spec:       re.RekordObj,
-	}
-
-	searchLogQuery.SetEntries([]models.ProposedEntry{entry})
-
-	searchParams.SetEntry(&searchLogQuery)
-	resp, err := rekorClient.Entries.SearchLogQuery(searchParams)
-	if err != nil {
-		return "", errors.Wrap(err, "searching log query")
-	}
-	if len(resp.Payload) == 0 {
-		return "", errors.New("signature not found in transparency log")
-	} else if len(resp.Payload) > 1 {
-		return "", errors.New("multiple entries returned; this should not happen")
-	}
-	logEntry := resp.Payload[0]
-	if len(logEntry) != 1 {
-		return "", errors.New("UUID value can not be extracted")
-	}
-
-	params := entries.NewGetLogEntryByUUIDParams()
-	for k := range logEntry {
-		params.EntryUUID = k
-	}
-	lep, err := rekorClient.Entries.GetLogEntryByUUID(params)
-	if err != nil {
-		return "", err
-	}
-
-	if len(lep.Payload) != 1 {
-		return "", errors.New("UUID value can not be extracted")
-	}
-	e := lep.Payload[params.EntryUUID]
-
-	hashes := [][]byte{}
-	for _, h := range e.Verification.InclusionProof.Hashes {
-		hb, _ := hex.DecodeString(h)
-		hashes = append(hashes, hb)
-	}
-
-	rootHash, _ := hex.DecodeString(*e.Verification.InclusionProof.RootHash)
-	leafHash, _ := hex.DecodeString(params.EntryUUID)
-
-	v := logverifier.New(hasher.DefaultHasher)
-	if err := v.VerifyInclusionProof(*e.Verification.InclusionProof.LogIndex, *e.Verification.InclusionProof.TreeSize, hashes, rootHash, leafHash); err != nil {
-		return "", errors.Wrap(err, "verifying inclusion proof")
-	}
-	return params.EntryUUID, nil
+	return resp.Location.String(), nil
 }
 
 func rekorEntry(payload, signature, pubKey []byte) rekord_v001.V001Entry {


### PR DESCRIPTION
This allows `signature.Signers` to provide `crypto.Signer`s to common libraries.

Signed-off-by: Jake Sanders <jsand@google.com>