### PR TITLE
cert.Subject is not populated, return serial instead

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -127,7 +127,8 @@ var signCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Received signing Cerificate: %+v\n", cert.Subject)
+
+		fmt.Println("Received signing cerificate with serial number: ", cert.SerialNumber)
 
 		signature, signedVal, err := signer.Sign(ctx, payload)
 		if err != nil {


### PR DESCRIPTION
Fulcio does not populate the Subject, so let's return the serial
instead.

Signed-off-by: Luke Hinds <lhinds@redhat.com>
