### PR TITLE
Add PublicKeyProvider interface

### DIFF
--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -43,9 +43,8 @@ func MarshalCertificateToPEM(cert *x509.Certificate) ([]byte, error) {
 // MarshalCertificatesToPEM converts the provided X509 certificates into PEM format
 func MarshalCertificatesToPEM(certs []*x509.Certificate) ([]byte, error) {
 	buf := bytes.Buffer{}
-	first := true
-	for _, cert := range certs {
-		if !first {
+	for i, cert := range certs {
+		if i != 0 {
 			_, _ = buf.WriteRune('\n')
 		}
 		pemBytes := pem.EncodeToMemory(&pem.Block{
@@ -53,7 +52,6 @@ func MarshalCertificatesToPEM(certs []*x509.Certificate) ([]byte, error) {
 			Bytes: cert.Raw,
 		})
 		_, _ = buf.Write(pemBytes)
-		first = false
 	}
 	return buf.Bytes(), nil
 }

--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -16,12 +16,12 @@
 package cryptoutils
 
 import (
+	"bytes"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
+	"io"
 	"time"
 )
 
@@ -38,6 +38,24 @@ func MarshalCertificateToPEM(cert *x509.Certificate) ([]byte, error) {
 		Type:  string(CertificatePEMType),
 		Bytes: cert.Raw,
 	}), nil
+}
+
+// MarshalCertificatesToPEM converts the provided X509 certificates into PEM format
+func MarshalCertificatesToPEM(certs []*x509.Certificate) ([]byte, error) {
+	buf := bytes.Buffer{}
+	first := true
+	for _, cert := range certs {
+		if !first {
+			_, _ = buf.WriteRune('\n')
+		}
+		pemBytes := pem.EncodeToMemory(&pem.Block{
+			Type:  string(CertificatePEMType),
+			Bytes: cert.Raw,
+		})
+		_, _ = buf.Write(pemBytes)
+		first = false
+	}
+	return buf.Bytes(), nil
 }
 
 // UnmarshalCertificatesFromPEM extracts one or more X509 certificates from the provided
@@ -64,9 +82,9 @@ func UnmarshalCertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) 
 }
 
 // LoadCertificatesFromPEMFile extracts one or more X509 certificates from the provided
-// path to a file.
-func LoadCertificatesFromPEMFile(path string) ([]*x509.Certificate, error) {
-	fileBytes, err := ioutil.ReadFile(filepath.Clean(path))
+// io.Reader.
+func LoadCertificatesFromPEM(pem io.Reader) ([]*x509.Certificate, error) {
+	fileBytes, err := io.ReadAll(pem)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -140,6 +140,13 @@ func LoadECDSAVerifier(pub *ecdsa.PublicKey, hashFunc crypto.Hash) (*ECDSAVerifi
 	}, nil
 }
 
+// PublicKey returns the public key that is used to verify signatures by
+// this verifier. As this value is held in memory, all options provided in arguments
+// to this method are ignored.
+func (e ECDSAVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error) {
+	return e.publicKey, nil
+}
+
 // VerifySignature verifies the signature for the given message. Unless provided
 // in an option, the digest of the message will be computed using the hash function specified
 // when the ECDSAVerifier was created.
@@ -217,4 +224,11 @@ func NewECDSASignerVerifier(curve elliptic.Curve, rand io.Reader, hashFunc crypt
 	}
 
 	return sv, priv, nil
+}
+
+// PublicKey returns the public key that is used to verify signatures by
+// this verifier. As this value is held in memory, all options provided in arguments
+// to this method are ignored.
+func (e ECDSASignerVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error) {
+	return e.publicKey, nil
 }

--- a/pkg/signature/ed25519_test.go
+++ b/pkg/signature/ed25519_test.go
@@ -42,7 +42,7 @@ func TestED25519SignerVerifier(t *testing.T) {
 		t.Errorf("unexpected error unmarshalling public key: %v", err)
 	}
 	edPriv, _ := privateKey.(ed25519.PrivateKey)
-	sv, err := LoadED25519SignerVerifier(&edPriv)
+	sv, err := LoadED25519SignerVerifier(edPriv)
 	if err != nil {
 		t.Errorf("unexpected error creating signer/verifier: %v", err)
 	}

--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -52,6 +52,19 @@ const (
 	Algorithm_RSA_PSS_4096_SHA512      = "rsa-pss-4096-sha512"
 )
 
+var algorithmMap = map[string]kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm{
+	Algorithm_ECDSA_P256_SHA256:        kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
+	Algorithm_ECDSA_P384_SHA384:        kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384,
+	Algorithm_RSA_PKCS1v15_2048_SHA256: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256,
+	Algorithm_RSA_PKCS1v15_3072_SHA256: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256,
+	Algorithm_RSA_PKCS1v15_4096_SHA256: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256,
+	Algorithm_RSA_PKCS1v15_4096_SHA512: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512,
+	Algorithm_RSA_PSS_2048_SHA256:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256,
+	Algorithm_RSA_PSS_3072_SHA256:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_3072_SHA256,
+	Algorithm_RSA_PSS_4096_SHA256:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA256,
+	Algorithm_RSA_PSS_4096_SHA512:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512,
+}
+
 type gcpClient struct {
 	defaultCtx context.Context
 	refString  string
@@ -369,19 +382,6 @@ func (g *gcpClient) createKey(ctx context.Context, algorithm string) (crypto.Pub
 	}
 	if _, err := g.kmsClient.GetCryptoKey(ctx, getKeyRequest); err == nil {
 		return g.public(ctx)
-	}
-
-	var algorithmMap = map[string]kmspb.CryptoKeyVersion_CryptoKeyVersionAlgorithm{
-		Algorithm_ECDSA_P256_SHA256:        kmspb.CryptoKeyVersion_EC_SIGN_P256_SHA256,
-		Algorithm_ECDSA_P384_SHA384:        kmspb.CryptoKeyVersion_EC_SIGN_P384_SHA384,
-		Algorithm_RSA_PKCS1v15_2048_SHA256: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_2048_SHA256,
-		Algorithm_RSA_PKCS1v15_3072_SHA256: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_3072_SHA256,
-		Algorithm_RSA_PKCS1v15_4096_SHA256: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA256,
-		Algorithm_RSA_PKCS1v15_4096_SHA512: kmspb.CryptoKeyVersion_RSA_SIGN_PKCS1_4096_SHA512,
-		Algorithm_RSA_PSS_2048_SHA256:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_2048_SHA256,
-		Algorithm_RSA_PSS_3072_SHA256:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_3072_SHA256,
-		Algorithm_RSA_PSS_4096_SHA256:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA256,
-		Algorithm_RSA_PSS_4096_SHA512:      kmspb.CryptoKeyVersion_RSA_SIGN_PSS_4096_SHA512,
 	}
 
 	if _, ok := algorithmMap[algorithm]; !ok {

--- a/pkg/signature/kms/gcp/signer.go
+++ b/pkg/signature/kms/gcp/signer.go
@@ -180,3 +180,14 @@ func (g *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) 
 
 	return csw, defaultHf, nil
 }
+
+func (g *SignerVerifier) SupportedAlgorithms() (result []string) {
+	for k := range algorithmMap {
+		result = append(result, k)
+	}
+	return
+}
+
+func (g *SignerVerifier) DefaultAlgorithm() string {
+	return Algorithm_ECDSA_P256_SHA256
+}

--- a/pkg/signature/kms/hashivault/signer.go
+++ b/pkg/signature/kms/hashivault/signer.go
@@ -38,6 +38,16 @@ const (
 	Algorithm_RSA_4096   = "rsa-4096"
 )
 
+var hvSupportedAlgorithms []string = []string{
+	Algorithm_ECDSA_P256,
+	Algorithm_ECDSA_P384,
+	Algorithm_ECDSA_P521,
+	Algorithm_ED25519,
+	Algorithm_RSA_2048,
+	Algorithm_RSA_3072,
+	Algorithm_RSA_4096,
+}
+
 var hvSupportedHashFuncs = []crypto.Hash{
 	crypto.SHA224,
 	crypto.SHA256,
@@ -191,4 +201,12 @@ func (h *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) 
 	}
 
 	return csw, h.hashFunc, nil
+}
+
+func (h *SignerVerifier) SupportedAlgorithms() []string {
+	return hvSupportedAlgorithms
+}
+
+func (h *SignerVerifier) DefaultAlgorithm() string {
+	return Algorithm_ECDSA_P256
 }

--- a/pkg/signature/kms/kms.go
+++ b/pkg/signature/kms/kms.go
@@ -70,4 +70,6 @@ type SignerVerifier interface {
 	signature.SignerVerifier
 	CreateKey(ctx context.Context, algorithm string) (crypto.PublicKey, error)
 	CryptoSigner(ctx context.Context, errFunc func(error)) (crypto.Signer, crypto.SignerOpts, error)
+	SupportedAlgorithms() []string
+	DefaultAlgorithm() string
 }

--- a/pkg/signature/publickey.go
+++ b/pkg/signature/publickey.go
@@ -1,0 +1,24 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"crypto"
+)
+
+type PublicKeyProvider interface {
+	PublicKey(opts ...PublicKeyOption) (crypto.PublicKey, error)
+}

--- a/pkg/signature/rsapkcs1v15.go
+++ b/pkg/signature/rsapkcs1v15.go
@@ -138,6 +138,13 @@ func LoadRSAPKCS1v15Verifier(pub *rsa.PublicKey, hashFunc crypto.Hash) (*RSAPKCS
 	}, nil
 }
 
+// PublicKey returns the public key that is used to verify signatures by
+// this verifier. As this value is held in memory, all options provided in arguments
+// to this method are ignored.
+func (r RSAPKCS1v15Verifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error) {
+	return r.publicKey, nil
+}
+
 // VerifySignature verifies the signature for the given message using PKCS1v15. Unless provided
 // in an option, the digest of the message will be computed using the hash function specified
 // when the RSAPKCS1v15Verifier was created.
@@ -212,4 +219,11 @@ func NewRSAPKCS1v15SignerVerifier(rand io.Reader, bits int, hashFunc crypto.Hash
 	}
 
 	return sv, priv, nil
+}
+
+// PublicKey returns the public key that is used to verify signatures by
+// this verifier. As this value is held in memory, all options provided in arguments
+// to this method are ignored.
+func (r RSAPKCS1v15SignerVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error) {
+	return r.publicKey, nil
 }

--- a/pkg/signature/rsapss.go
+++ b/pkg/signature/rsapss.go
@@ -158,6 +158,13 @@ func LoadRSAPSSVerifier(pub *rsa.PublicKey, hashFunc crypto.Hash, opts *rsa.PSSO
 	}, nil
 }
 
+// PublicKey returns the public key that is used to verify signatures by
+// this verifier. As this value is held in memory, all options provided in arguments
+// to this method are ignored.
+func (r RSAPSSVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error) {
+	return r.publicKey, nil
+}
+
 // VerifySignature verifies the signature for the given message using PSS. Unless provided
 // in an option, the digest of the message will be computed using the hash function specified
 // when the RSAPSSVerifier was created.
@@ -240,4 +247,11 @@ func NewRSAPSSSignerVerifier(rand io.Reader, bits int, hashFunc crypto.Hash) (*R
 	}
 
 	return sv, priv, nil
+}
+
+// PublicKey returns the public key that is used to verify signatures by
+// this verifier. As this value is held in memory, all options provided in arguments
+// to this method are ignored.
+func (r RSAPSSSignerVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error) {
+	return r.publicKey, nil
 }

--- a/pkg/signature/signer.go
+++ b/pkg/signature/signer.go
@@ -37,10 +37,10 @@ import (
 )
 
 type Signer interface {
+	PublicKeyProvider
 	SignMessage(message io.Reader, opts ...SignOption) ([]byte, error)
 	// THIS WILL BE REMOVED AS SOON AS WE CAN UPDATE SIGSTORE DEPENDENCIES
 	Sign(context.Context, []byte) ([]byte, []byte, error)
-	PublicKey(opts ...PublicKeyOption) (crypto.PublicKey, error)
 }
 
 // SignerOpts implements crypto.SignerOpts but also allows callers to specify
@@ -66,7 +66,7 @@ func LoadSigner(privateKey crypto.PrivateKey, hashFunc crypto.Hash) (Signer, err
 		return LoadRSAPKCS1v15Signer(pk, hashFunc)
 	case *ecdsa.PrivateKey:
 		return LoadECDSASigner(pk, hashFunc)
-	case *ed25519.PrivateKey:
+	case ed25519.PrivateKey:
 		return LoadED25519Signer(pk)
 	}
 	return nil, errors.New("unsupported public key type")

--- a/pkg/signature/signerverifier.go
+++ b/pkg/signature/signerverifier.go
@@ -43,7 +43,7 @@ func LoadSignerVerifier(privateKey crypto.PrivateKey, hashFunc crypto.Hash) (Sig
 		return LoadRSAPKCS1v15SignerVerifier(pk, hashFunc)
 	case *ecdsa.PrivateKey:
 		return LoadECDSASignerVerifier(pk, hashFunc)
-	case *ed25519.PrivateKey:
+	case ed25519.PrivateKey:
 		return LoadED25519SignerVerifier(pk)
 	}
 	return nil, errors.New("unsupported public key type")

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -29,6 +29,7 @@ import (
 )
 
 type Verifier interface {
+	PublicKeyProvider
 	VerifySignature(signature, message io.Reader, opts ...VerifyOption) error
 }
 
@@ -43,8 +44,8 @@ func LoadVerifier(publicKey crypto.PublicKey, hashFunc crypto.Hash) (Verifier, e
 		return LoadRSAPKCS1v15Verifier(pk, hashFunc)
 	case *ecdsa.PublicKey:
 		return LoadECDSAVerifier(pk, hashFunc)
-	case *ed25519.PublicKey:
-		return LoadED25519Verifier(*pk)
+	case ed25519.PublicKey:
+		return LoadED25519Verifier(pk)
 	}
 	return nil, errors.New("unsupported public key type")
 }


### PR DESCRIPTION
Given the requirements of cosign, I split out the PublicKey() method into its own interface such that it can be implemented by both signers and verifiers (since both have a public key).

Also small fixes including:
 - ed25519 passes by value rather than pointer for public/private keys
 - adds SupportedAlgorithms() and DefaultAlgorithm() method for KMS SignerVerifiers (ideal for use in CreateKey() method)

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
