### PR TITLE
Fix for Error: error during PEM decoding

### DIFF
--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -45,11 +45,13 @@ func MarshalCertificateToPEM(cert *x509.Certificate) ([]byte, error) {
 func UnmarshalCertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) {
 	result := []*x509.Certificate{}
 	remaining := pemBytes
+
 	for {
-		if remaining == nil {
+		if len(remaining) == 0 {
 			break
 		}
 		certDer, restBytes := pem.Decode(remaining)
+
 		if certDer == nil {
 			return nil, errors.New("error during PEM decoding")
 		}


### PR DESCRIPTION
Break condition was trying to match an empty array with nil

This resulted in no break condition and the error working down
to `error during PEM decoding`

Instead match on an empty length

Signed-off-by: Luke Hinds <lhinds@redhat.com>
