### PR TITLE
Add formatted URL for rekor entry

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -119,7 +119,7 @@ var signCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Println("Received signing cerificate with serial number: ", signingCert.SerialNumber)
+		fmt.Println("Received signing certificate with serial number: ", signingCert.SerialNumber)
 
 		signature, err := signer.SignMessage(bytes.NewReader(payload))
 		if err != nil {

--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -121,8 +121,6 @@ var signCmd = &cobra.Command{
 
 		fmt.Println("Received signing cerificate with serial number: ", signingCert.SerialNumber)
 
-		fmt.Printf("Received signing Cerificate: %+v\n", signingCert.Subject)
-
 		signature, err := signer.SignMessage(bytes.NewReader(payload))
 		if err != nil {
 			panic(fmt.Sprintf("Error occurred while during artifact signing: %s", err))
@@ -139,7 +137,9 @@ var signCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println("Rekor entry successful. URL: ", tlogEntry)
+
+		fmt.Printf("Rekor entry successful. URL: %v%v\n", viper.GetString("rekor-server"), tlogEntry)
+
 		return nil
 	},
 }


### PR DESCRIPTION
Also remove `signingCert.Subject` which returns an empty result

![image](https://user-images.githubusercontent.com/7058938/124596817-9dc09900-de5a-11eb-9383-c9b694264e6a.png)


Signed-off-by: Luke Hinds <lhinds@redhat.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
