### PR TITLE
filehandler: add application/x-executable to supported mimetype

### DIFF
--- a/pkg/utils/filehandler.go
+++ b/pkg/utils/filehandler.go
@@ -20,6 +20,7 @@ import "github.com/gabriel-vasile/mimetype"
 var SupportedFileTypes = map[string]struct{}{
 	"text/plain; charset=utf-8":     {},
 	"application/jar":               {},
+	"application/x-executable":      {},
 	"application/x-bzip2":           {},
 	"application/x-tar":             {},
 	"application/x-gzip":            {},


### PR DESCRIPTION
While doing the fulcio release notice the mime-type `application/x-executable` was not supported. adding this the list of supported mime-types

