### PR TITLE
compute crc over digest instead of message

### DIFF
--- a/pkg/signature/kms/gcp/signer.go
+++ b/pkg/signature/kms/gcp/signer.go
@@ -91,10 +91,13 @@ func (g *SignerVerifier) SignMessage(message io.Reader, opts ...signature.SignOp
 		opt.ApplyCryptoSignerOpts(&signerOpts)
 	}
 
-	crc32cHasher := crc32.New(crc32.MakeTable(crc32.Castagnoli))
-	messageAndCRC32CReader := io.TeeReader(message, crc32cHasher)
+	digest, hf, err := signature.ComputeDigestForSigning(message, signerOpts.HashFunc(), gcpSupportedHashFuncs, opts...)
+	if err != nil {
+		return nil, err
+	}
 
-	digest, hf, err := signature.ComputeDigestForSigning(messageAndCRC32CReader, signerOpts.HashFunc(), gcpSupportedHashFuncs, opts...)
+	crc32cHasher := crc32.New(crc32.MakeTable(crc32.Castagnoli))
+	_, err = crc32cHasher.Write(digest)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
