### PR TITLE
We should use the client ID from the oauth config, not viper.

### DIFF
--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -27,7 +27,6 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/segmentio/ksuid"
 	"github.com/skratchdot/open-golang/open"
-	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
 )
 
@@ -84,7 +83,7 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 	}
 
 	// verify nonce, client ID, access token hash before using it
-	verifier := p.Verifier(&oidc.Config{ClientID: viper.GetString("oidc-client-id")})
+	verifier := p.Verifier(&oidc.Config{ClientID: cfg.ClientID})
 	parsedIDToken, err := verifier.Verify(context.Background(), idToken)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
