### PR TITLE
Don't use pointers for ed25519 keys

### DIFF
--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -32,7 +32,7 @@ var ed25519SupportedHashFuncs = []crypto.Hash{
 }
 
 type ED25519Signer struct {
-	priv *ed25519.PrivateKey
+	priv ed25519.PrivateKey
 }
 
 // LoadED25519Signer calculates signatures using the specified private key.
@@ -47,7 +47,7 @@ func LoadED25519Signer(priv ed25519.PrivateKey) (*ED25519Signer, error) {
 	}
 
 	return &ED25519Signer{
-		priv: &priv,
+		priv: priv,
 	}, nil
 }
 
@@ -62,7 +62,7 @@ func (e ED25519Signer) SignMessage(message io.Reader, _ ...SignOption) ([]byte, 
 		return nil, err
 	}
 
-	return ed25519.Sign(*e.priv, messageBytes), nil
+	return ed25519.Sign(e.priv, messageBytes), nil
 }
 
 // Public returns the public key that can be used to verify signatures created by
@@ -98,7 +98,7 @@ func (e ED25519Signer) CSign(_ io.Reader, message []byte, _ crypto.SignerOpts) (
 }
 
 type ED25519Verifier struct {
-	publicKey *ed25519.PublicKey
+	publicKey ed25519.PublicKey
 }
 
 // LoadED25519Verifier returns a Verifier that verifies signatures using the specified ED25519 public key.
@@ -108,7 +108,7 @@ func LoadED25519Verifier(pub ed25519.PublicKey) (*ED25519Verifier, error) {
 	}
 
 	return &ED25519Verifier{
-		publicKey: &pub,
+		publicKey: pub,
 	}, nil
 }
 
@@ -139,7 +139,7 @@ func (e *ED25519Verifier) VerifySignature(signature, message io.Reader, _ ...Ver
 		return errors.Wrap(err, "reading signature")
 	}
 
-	if !ed25519.Verify(*e.publicKey, messageBytes, sigBytes) {
+	if !ed25519.Verify(e.publicKey, messageBytes, sigBytes) {
 		return errors.New("failed to verify signature")
 	}
 	return nil
@@ -171,13 +171,13 @@ func LoadED25519SignerVerifier(priv ed25519.PrivateKey) (*ED25519SignerVerifier,
 
 // NewDefaultED25519SignerVerifier creates a combined signer and verifier using ED25519.
 // This creates a new ED25519 key using crypto/rand as an entropy source.
-func NewDefaultED25519SignerVerifierE() (*ED25519SignerVerifier, *ed25519.PrivateKey, error) {
+func NewDefaultED25519SignerVerifierE() (*ED25519SignerVerifier, ed25519.PrivateKey, error) {
 	return NewED25519SignerVerifier(rand.Reader)
 }
 
 // NewED25519SignerVerifier creates a combined signer and verifier using ED25519.
 // This creates a new ED25519 key using the specified entropy source.
-func NewED25519SignerVerifier(rand io.Reader) (*ED25519SignerVerifier, *ed25519.PrivateKey, error) {
+func NewED25519SignerVerifier(rand io.Reader) (*ED25519SignerVerifier, ed25519.PrivateKey, error) {
 	_, priv, err := ed25519.GenerateKey(rand)
 	if err != nil {
 		return nil, nil, err
@@ -188,7 +188,7 @@ func NewED25519SignerVerifier(rand io.Reader) (*ED25519SignerVerifier, *ed25519.
 		return nil, nil, err
 	}
 
-	return sv, &priv, nil
+	return sv, priv, nil
 }
 
 // PublicKey returns the public key that is used to verify signatures by

--- a/pkg/signature/ed25519_test.go
+++ b/pkg/signature/ed25519_test.go
@@ -39,27 +39,44 @@ MCowBQYDK2VwAyEA9wy4umF4RHQ8UQXo8fzEQNBWE4GsBMkCzQPAfHvkf/s=
 func TestED25519SignerVerifier(t *testing.T) {
 	privateKey, err := cryptoutils.UnmarshalPEMToPrivateKey([]byte(ed25519Priv), cryptoutils.SkipPassword)
 	if err != nil {
-		t.Errorf("unexpected error unmarshalling public key: %v", err)
+		t.Fatalf("unexpected error unmarshalling public key: %v", err)
 	}
-	edPriv, _ := privateKey.(ed25519.PrivateKey)
+	edPriv := privateKey.(ed25519.PrivateKey)
+
 	sv, err := LoadED25519SignerVerifier(edPriv)
 	if err != nil {
-		t.Errorf("unexpected error creating signer/verifier: %v", err)
+		t.Fatalf("unexpected error creating signer/verifier: %v", err)
 	}
 
 	message := []byte("sign me")
 	sig, _ := base64.StdEncoding.DecodeString("cnafwd8DKq2nQ564eN66ckYV8anVFGFi5vaYiQg2aal7ej/J0/OE0PPdKHLHe9wdzWRMFy5MpurRD/2cGXGLBQ==")
 	testingSigner(t, sv, "ed25519", crypto.SHA256, message)
 	testingVerifier(t, sv, "ed25519", crypto.SHA256, sig, message)
+	pub, err := sv.PublicKey()
+	if err != nil {
+		t.Fatalf("unexpected error from PublicKey(): %v", err)
+	}
+	assertPublicKeyIsx509Marshalable(t, pub)
+}
 
+func TestED25519Verifier(t *testing.T) {
 	publicKey, err := cryptoutils.UnmarshalPEMToPublicKey([]byte(ed25519Pub))
 	if err != nil {
-		t.Errorf("unexpected error unmarshalling public key: %v", err)
+		t.Fatalf("unexpected error unmarshalling public key: %v", err)
 	}
-	edPub, _ := publicKey.(ed25519.PublicKey)
+	edPub := publicKey.(ed25519.PublicKey)
+
 	v, err := LoadED25519Verifier(edPub)
 	if err != nil {
-		t.Errorf("unexpected error creating verifier: %v", err)
+		t.Fatalf("unexpected error creating verifier: %v", err)
 	}
+
+	message := []byte("sign me")
+	sig, _ := base64.StdEncoding.DecodeString("cnafwd8DKq2nQ564eN66ckYV8anVFGFi5vaYiQg2aal7ej/J0/OE0PPdKHLHe9wdzWRMFy5MpurRD/2cGXGLBQ==")
 	testingVerifier(t, v, "ed25519", crypto.SHA256, sig, message)
+	pub, err := v.PublicKey()
+	if err != nil {
+		t.Fatalf("unexpected error from PublicKey(): %v", err)
+	}
+	assertPublicKeyIsx509Marshalable(t, pub)
 }

--- a/pkg/signature/sv_test.go
+++ b/pkg/signature/sv_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"crypto"
 	crand "crypto/rand"
+	"crypto/x509"
 	"strings"
 	"testing"
 
@@ -115,6 +116,14 @@ func testingSigner(t *testing.T, s Signer, alg string, hashFunc crypto.Hash, mes
 			t.Errorf("PublicKey(context.Background()) returned empty key or err: %v", err)
 		}
 	*/
+}
+
+func assertPublicKeyIsx509Marshalable(t *testing.T, pub crypto.PublicKey) {
+	t.Helper()
+
+	if _, err := x509.MarshalPKIXPublicKey(pub); err != nil {
+		t.Errorf("x509.MarshalPKIXPublicKey(%T) returned error: %v", pub, err)
+	}
 }
 
 func testingVerifier(t *testing.T, v Verifier, alg string, hashFunc crypto.Hash, signature, message []byte) {


### PR DESCRIPTION
stdlib assumes `ed25519.(Public, Private)Key` by value ([example](https://golang.org/pkg/crypto/x509/#MarshalPKCS8PrivateKey))

Signed-off-by: Jake Sanders <jsand@google.com>