### PR TITLE
Transit backend path is hardcoded for some operations of the KMS Vault client

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -163,7 +163,7 @@ func (h *hashivaultClient) public() (crypto.PublicKey, error) {
 func (h hashivaultClient) sign(digest []byte, alg crypto.Hash) ([]byte, error) {
 	client := h.client.Logical()
 
-	signResult, err := client.Write(fmt.Sprintf("/transit/sign/%s%s", h.keyPath, hashString(alg)), map[string]interface{}{
+	signResult, err := client.Write(fmt.Sprintf("/%s/sign/%s%s", h.transitSecretEnginePath, h.keyPath, hashString(alg)), map[string]interface{}{
 		"input":     base64.StdEncoding.Strict().EncodeToString(digest),
 		"prehashed": alg != crypto.Hash(0),
 	})
@@ -233,7 +233,7 @@ func hashString(h crypto.Hash) string {
 func (h hashivaultClient) createKey(typeStr string) (crypto.PublicKey, error) {
 	client := h.client.Logical()
 
-	if _, err := client.Write(fmt.Sprintf("/transit/keys/%s", h.keyPath), map[string]interface{}{
+	if _, err := client.Write(fmt.Sprintf("/%s/keys/%s", h.transitSecretEnginePath, h.keyPath), map[string]interface{}{
 		"type": typeStr,
 	}); err != nil {
 		return nil, errors.Wrap(err, "Failed to create transit key")


### PR DESCRIPTION
The environment variable TRANSIT_SECRET_ENGINE_PATH is not always used.

Some operations are hardcoded to "transit/". Users with a transit backend mounted with a non default path might not be able to use it.

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
