### PR TITLE
leverage Vault token helpers approach while obtaining Vault token

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,5 @@ require (
 	google.golang.org/genproto v0.0.0-20210722135532-667f2b7c528f
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/square/go-jose.v2 v2.6.0
+	github.com/mitchellh/go-homedir v1.1.0
 )


### PR DESCRIPTION
There is a concept called [Token Helpers](https://www.vaultproject.io/docs/commands/token-helper) in Vault. By default, the Vault CLI will store the generated token on disk in the `~/.vault-token` file. So, I realized that even though we could not set the `VAULT_TOKEN` env variable, we can still obtain the Vault token from the file with the help of this feature. So, this PR will add that support to the Vault client initialization process.

Btw, this is just an idea, so please feel free to comment it out.

![Screen Shot 2021-07-25 at 11 58 14](https://user-images.githubusercontent.com/16693043/126893683-90e67730-c6b7-4051-91a4-3d1ed4fa9101.png)

![Screen Shot 2021-07-25 at 11 58 29](https://user-images.githubusercontent.com/16693043/126893680-71512080-1557-4751-b924-a44cc0a996d7.png)
