### PR TITLE
default to P-256 curve again

### DIFF
--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -196,9 +196,9 @@ func LoadECDSASignerVerifier(priv *ecdsa.PrivateKey, hf crypto.Hash) (*ECDSASign
 
 // NewDefaultECDSASignerVerifier creates a combined signer and verifier using ECDSA.
 //
-// This creates a new ECDSA key using the P-384 curve and uses the SHA256 hashing algorithm.
+// This creates a new ECDSA key using the P-256 curve and uses the SHA256 hashing algorithm.
 func NewDefaultECDSASignerVerifier() (*ECDSASignerVerifier, *ecdsa.PrivateKey, error) {
-	return NewECDSASignerVerifier(elliptic.P384(), rand.Reader, crypto.SHA256)
+	return NewECDSASignerVerifier(elliptic.P256(), rand.Reader, crypto.SHA256)
 }
 
 // NewECDSASignerVerifier creates a combined signer and verifier using ECDSA.


### PR DESCRIPTION
After discussion regarding also. defaulting to P-384 in Cosign, we decided to stick with P-256 due to broad popularity, support, and performance. https://malware.news/t/everyone-loves-curves-but-which-elliptic-curve-is-the-most-popular/17657

Not _too_ opinionated, but would prefer to err on the side of consistency unless there's a good reason why the default was change to P-384 in the first place