### PR TITLE
Integration tests for dex / OIDConnect

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -28,17 +28,6 @@ jobs:
   e2e_test:
     name: e2e integration tests
     runs-on: ubuntu-latest
-    services:
-      vault:
-        image: vault
-        env:
-          VAULT_DEV_ROOT_TOKEN_ID: testtoken
-        ports:
-        - 8200/tcp
-      localstack:
-        image: localstack/localstack:0.12.15
-        ports:
-        - 4566/tcp
     steps:
     - uses: actions/checkout@v2
 
@@ -65,8 +54,6 @@ jobs:
       working-directory: ./test/e2e
       run: docker-compose build
 
-    - name: Unit Test
-      run: go test -tags e2e -v ./test/e2e/...
     - name: Integeration test
       working-directory: ./test/e2e
       run: ./e2e-test.sh

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -54,6 +54,6 @@ jobs:
       working-directory: ./test/e2e
       run: docker-compose build
 
-    - name: Integeration test
+    - name: Integration test
       working-directory: ./test/e2e
       run: ./e2e-test.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,6 +75,13 @@ jobs:
         image: localstack/localstack:0.12.15
         ports:
         - 4566/tcp
+      dex:
+        image: ghcr.io/dexidp/dex:v2.30.0
+        ports:
+          - 5556/tcp
+        volumes:
+          - ${{ github.workspace }}:/workspace
+        command: [ "dex", "serve", "/workspace/test/e2e/oauthflow/dex-config.yml" ]
     steps:
     - uses: actions/checkout@v2
 
@@ -103,7 +110,7 @@ jobs:
         AWS_REGION: us-east-1
         AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
         AWS_TLS_INSECURE_SKIP_VERIFY: 1
-        OIDC_ISSUER: http://127.0.0.1:5556/auth
+        OIDC_ISSUER: http://localhost:5556/auth
         OIDC_ID: sigstore
         OIDC_SECRET: mock-secret
         INTEGRATION_TEST: 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -103,5 +103,8 @@ jobs:
         AWS_REGION: us-east-1
         AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
         AWS_TLS_INSECURE_SKIP_VERIFY: 1
+        OIDC_ISSUER: http://127.0.0.1:5556/auth
+        OIDC_ID: sigstore
+        OIDC_SECRET: mock-secret
         INTEGRATION_TEST: 1
       run: go test -tags e2e -v ./test/e2e/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,11 +84,11 @@ jobs:
     - name: Install chrome
       run: sudo apt install ./google-chrome-stable_current_amd64.deb
     - name: Docker Build
-      working-directory: ./tests/e2e
+      working-directory: ./test/e2e
       run: docker-compose build
 
     - name: Unit Test
       run: go test -tags e2e -v ./test/e2e/...
     - name: Integeration test
-      working-directory: ./tests/e2e
+      working-directory: ./test/e2e
       run: ./e2e-test.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,6 +76,8 @@ jobs:
         ports:
         - 4566/tcp
     steps:
+    - uses: browser-actions/setup-chrome@latest
+
     - uses: actions/checkout@v2
 
     - name: Set up Go
@@ -99,4 +101,5 @@ jobs:
         AWS_REGION: us-east-1
         AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
         AWS_TLS_INSECURE_SKIP_VERIFY: 1
+        INTEGRATION_TEST: 1
       run: go test -tags e2e -v ./test/e2e/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,18 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
+      VAULT_TOKEN: testtoken
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
+      AWS_TLS_INSECURE_SKIP_VERIFY: 1
+      OIDC_ISSUER: http://localhost:5556/auth
+      OIDC_ID: sigstore
+      OIDC_SECRET: mock-secret
+      INTEGRATION_TEST: 1
     steps:
     - uses: actions/checkout@v2
 
@@ -88,18 +100,5 @@ jobs:
     - name: Unit Test
       run: go test -tags e2e -v ./test/e2e/...
     - name: Integeration test
-
-      env:
-        VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
-        VAULT_TOKEN: testtoken
-        AWS_ACCESS_KEY_ID: test
-        AWS_SECRET_ACCESS_KEY: test
-        AWS_REGION: us-east-1
-        AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
-        AWS_TLS_INSECURE_SKIP_VERIFY: 1
-        OIDC_ISSUER: http://localhost:5556/auth
-        OIDC_ID: sigstore
-        OIDC_SECRET: mock-secret
-        INTEGRATION_TEST: 1
-        working-directory: ./tests/e2e
-        run: ./e2e-test.sh
+      working-directory: ./tests/e2e
+      run: ./e2e-test.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,18 +64,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    env:
-      VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
-      VAULT_TOKEN: testtoken
-      AWS_ACCESS_KEY_ID: test
-      AWS_SECRET_ACCESS_KEY: test
-      AWS_REGION: us-east-1
-      AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
-      AWS_TLS_INSECURE_SKIP_VERIFY: 1
-      OIDC_ISSUER: http://localhost:5556/auth
-      OIDC_ID: sigstore
-      OIDC_SECRET: mock-secret
-      INTEGRATION_TEST: 1
     needs: [build]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,8 +76,6 @@ jobs:
         ports:
         - 4566/tcp
     steps:
-    - uses: browser-actions/setup-chrome@latest
-
     - uses: actions/checkout@v2
 
     - name: Set up Go
@@ -91,6 +89,10 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+    - name: Pull chrome
+      run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    - name: Install chrome
+      run: sudo apt install ./google-chrome-stable_current_amd64.deb
 
     - name: Test
       env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,24 +64,6 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: [build]
-    services:
-      vault:
-        image: vault
-        env:
-          VAULT_DEV_ROOT_TOKEN_ID: testtoken
-        ports:
-        - 8200/tcp
-      localstack:
-        image: localstack/localstack:0.12.15
-        ports:
-        - 4566/tcp
-      dex:
-        image: ghcr.io/dexidp/dex:v2.30.0
-        ports:
-          - 5556/tcp
-        volumes:
-          - ${{ github.workspace }}:/workspace
-        command: [ "dex", "serve", "/workspace/test/e2e/oauthflow/dex-config.yml" ]
     steps:
     - uses: actions/checkout@v2
 
@@ -100,8 +82,13 @@ jobs:
       run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
     - name: Install chrome
       run: sudo apt install ./google-chrome-stable_current_amd64.deb
+    - name: Docker Build
+      run: docker-compose build
 
-    - name: Test
+    - name: Unit Test
+      run: go test -tags e2e -v ./test/e2e/...
+    - name: Integeration test
+
       env:
         VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
         VAULT_TOKEN: testtoken
@@ -114,4 +101,5 @@ jobs:
         OIDC_ID: sigstore
         OIDC_SECRET: mock-secret
         INTEGRATION_TEST: 1
-      run: go test -tags e2e -v ./test/e2e/...
+        working-directory: ./tests/e2e
+        run: ./e2e-test.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,6 +65,18 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: [build]
+    env:
+      AULT_TOKEN: testtoken
+      VAULT_ADDR: http://localhost:8200/
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT: localhost:4566
+      AWS_TLS_INSECURE_SKIP_VERIFY: 1
+      OIDC_ISSUER: http://127.0.0.1:5556/auth
+      OIDC_ID: sigstore
+      OIDC_SECRET: mock-secret
+      INTEGRATION_TEST: 1
     steps:
     - uses: actions/checkout@v2
 
@@ -72,6 +84,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ env.GO_VERSION }}
+
     - name: Cache Modules
       uses: actions/cache@v2
       with:
@@ -79,10 +92,13 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
+
     - name: Pull chrome
       run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+
     - name: Install chrome
       run: sudo apt install ./google-chrome-stable_current_amd64.deb
+
     - name: Docker Build
       working-directory: ./test/e2e
       run: docker-compose build
@@ -91,16 +107,4 @@ jobs:
       run: go test -tags e2e -v ./test/e2e/...
     - name: Integeration test
       working-directory: ./test/e2e
-      env:
-        AULT_TOKEN: testtoken
-        VAULT_ADDR: http://localhost:8200/
-        AWS_ACCESS_KEY_ID: test
-        AWS_SECRET_ACCESS_KEY: test
-        AWS_REGION: us-east-1
-        AWS_ENDPOINT: localhost:4566
-        AWS_TLS_INSECURE_SKIP_VERIFY: 1
-        OIDC_ISSUER: http://127.0.0.1:5556/auth
-        OIDC_ID: sigstore
-        OIDC_SECRET: mock-secret
-        INTEGRATION_TEST: 1
       run: ./e2e-test.sh

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,6 +84,7 @@ jobs:
     - name: Install chrome
       run: sudo apt install ./google-chrome-stable_current_amd64.deb
     - name: Docker Build
+      working-directory: ./tests/e2e
       run: docker-compose build
 
     - name: Unit Test

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,18 +30,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
-      VAULT_TOKEN: testtoken
-      AWS_ACCESS_KEY_ID: test
-      AWS_SECRET_ACCESS_KEY: test
-      AWS_REGION: us-east-1
-      AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
-      AWS_TLS_INSECURE_SKIP_VERIFY: 1
-      OIDC_ISSUER: http://localhost:5556/auth
-      OIDC_ID: sigstore
-      OIDC_SECRET: mock-secret
-      INTEGRATION_TEST: 1
+
     steps:
     - uses: actions/checkout@v2
 
@@ -75,6 +64,18 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    env:
+      VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
+      VAULT_TOKEN: testtoken
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
+      AWS_TLS_INSECURE_SKIP_VERIFY: 1
+      OIDC_ISSUER: http://localhost:5556/auth
+      OIDC_ID: sigstore
+      OIDC_SECRET: mock-secret
+      INTEGRATION_TEST: 1
     needs: [build]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -91,4 +91,16 @@ jobs:
       run: go test -tags e2e -v ./test/e2e/...
     - name: Integeration test
       working-directory: ./test/e2e
+      env:
+        AULT_TOKEN: testtoken
+        VAULT_ADDR: http://localhost:8200/
+        AWS_ACCESS_KEY_ID: test
+        AWS_SECRET_ACCESS_KEY: test
+        AWS_REGION: us-east-1
+        AWS_ENDPOINT: localhost:4566
+        AWS_TLS_INSECURE_SKIP_VERIFY: 1
+        OIDC_ISSUER: http://127.0.0.1:5556/auth
+        OIDC_ID: sigstore
+        OIDC_SECRET: mock-secret
+        INTEGRATION_TEST: 1
       run: ./e2e-test.sh

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sigstore/sigstore
 go 1.16
 
 require (
-	bou.ke/monkey v1.0.2 // indirect
+	bou.ke/monkey v1.0.2
 	cloud.google.com/go v0.88.0
 	github.com/Azure/azure-sdk-for-go v55.8.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.19 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sigstore/sigstore
 go 1.16
 
 require (
+	bou.ke/monkey v1.0.2 // indirect
 	cloud.google.com/go v0.88.0
 	github.com/Azure/azure-sdk-for-go v55.8.0+incompatible
 	github.com/Azure/go-autorest/autorest v0.11.19 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/ReneKroon/ttlcache/v2 v2.7.0
 	github.com/aws/aws-sdk-go v1.40.7
 	github.com/coreos/go-oidc/v3 v3.0.0
+	github.com/go-rod/rod v0.101.8
 	github.com/go-test/deep v1.0.7
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-containerregistry v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,8 @@ github.com/go-openapi/spec v0.19.3/go.mod h1:FpwSN1ksY1eteniUU7X0N/BgJ7a4WvBFVA8
 github.com/go-openapi/swag v0.0.0-20160704191624-1d0bd113de87/go.mod h1:DXUve3Dpr1UfpPtxFw+EFuQ41HhCWZfha5jSVRG7C7I=
 github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-rod/rod v0.101.8 h1:oV0O97uwjkCVyAP0hD6K6bBE8FUMIjs0dtF7l6kEBsU=
+github.com/go-rod/rod v0.101.8/go.mod h1:N/zlT53CfSpq74nb6rOR0K8UF0SPUPBmzBnArrms+mY=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
@@ -517,6 +519,16 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/ysmood/goob v0.3.0 h1:XZ51cZJ4W3WCoCiUktixzMIQF86W7G5VFL4QQ/Q2uS0=
+github.com/ysmood/goob v0.3.0/go.mod h1:S3lq113Y91y1UBf1wj1pFOxeahvfKkCk6mTWTWbDdWs=
+github.com/ysmood/got v0.15.1 h1:X5jAbMyBf5yeezuFMp9HaMGXZWMSqIQcUlAHI+kJmUs=
+github.com/ysmood/got v0.15.1/go.mod h1:pE1l4LOwOBhQg6A/8IAatkGp7uZjnalzrZolnlhhMgY=
+github.com/ysmood/gotrace v0.2.2 h1:006KHGRThSRf8lwh4EyhNmuuq/l+Ygs+JqojkhEG1/E=
+github.com/ysmood/gotrace v0.2.2/go.mod h1:TzhIG7nHDry5//eYZDYcTzuJLYQIkykJzCRIo4/dzQM=
+github.com/ysmood/gson v0.6.4 h1:Yb6tosv6bk59HqjZu2/7o4BFherpYEMkDkXmlhgryZ4=
+github.com/ysmood/gson v0.6.4/go.mod h1:3Kzs5zDl21g5F/BlLTNcuAGAYLKt2lV5G8D1zF3RNmg=
+github.com/ysmood/leakless v0.7.0 h1:XCGdaPExyoreoQd+H5qgxM3ReNbSPFsEXpSKwbXbwQw=
+github.com/ysmood/leakless v0.7.0/go.mod h1:R8iAXPRaG97QJwqxs74RdwzcRHT1SWCGTNqY8q0JvMQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -61,7 +61,7 @@ func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCI
 		ClientID:     id,
 		ClientSecret: secret,
 		Endpoint:     provider.Endpoint(),
-		RedirectURL:  "http://localhost:5555/auth/callback",
+		RedirectURL:  "http://localhost:5557/auth/callback",
 		Scopes:       []string{oidc.ScopeOpenID, "email"},
 	}
 

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -61,7 +61,7 @@ func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCI
 		ClientID:     id,
 		ClientSecret: secret,
 		Endpoint:     provider.Endpoint(),
-		RedirectURL:  "http://localhost:5556/auth/callback",
+		RedirectURL:  "http://localhost:5555/auth/callback",
 		Scopes:       []string{oidc.ScopeOpenID, "email"},
 	}
 

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -25,15 +25,15 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-rod/rod"
 	"github.com/segmentio/ksuid"
 	"github.com/skratchdot/open-golang/open"
 	"golang.org/x/oauth2"
-	"github.com/go-rod/rod"
 )
 
 const (
-	oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
-	integrationTest    = "INTEGRATION_TEST"
+	oobRedirectURI  = "urn:ietf:wg:oauth:2.0:oob"
+	integrationTest = "INTEGRATION_TEST"
 )
 
 // InteractiveIDTokenGetter is a type to get ID tokens for oauth flows
@@ -80,7 +80,7 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 		// This code will only run in integration tests
 		page := rod.New().MustConnect().MustPage(authCodeURL)
 		page.MustElement("body > div.dex-container > div > div > div:nth-child(2) > a > button").MustClick()
-		code, err = getCodeFromLocalServer(stateToken, redirectURL)
+		code, _ = getCodeFromLocalServer(stateToken, redirectURL)
 	}
 	token, err := cfg.Exchange(context.Background(), code, append(pkce.TokenURLOpts(), oidc.Nonce(nonce))...)
 	if err != nil {

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -25,16 +25,12 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/go-rod/rod"
 	"github.com/segmentio/ksuid"
 	"github.com/skratchdot/open-golang/open"
 	"golang.org/x/oauth2"
 )
 
-const (
-	oobRedirectURI  = "urn:ietf:wg:oauth:2.0:oob"
-	integrationTest = "INTEGRATION_TEST"
-)
+const oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
 
 // InteractiveIDTokenGetter is a type to get ID tokens for oauth flows
 type InteractiveIDTokenGetter struct {
@@ -61,26 +57,17 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 	opts := append(pkce.AuthURLOpts(), oauth2.AccessTypeOnline, oidc.Nonce(nonce))
 	authCodeURL := cfg.AuthCodeURL(stateToken, opts...)
 	var code string
-	// Check if we are running integration tests
-	inTest := os.Getenv(integrationTest)
-	if inTest == "" {
-		if err := open.Run(authCodeURL); err != nil {
-			// Swap to the out of band flow if we can't open the browser
-			fmt.Fprintf(os.Stderr, "error opening browser: %v\n", err)
-			code = doOobFlow(&cfg, stateToken, opts)
-		} else {
-			fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", authCodeURL)
-			code, err = getCodeFromLocalServer(stateToken, redirectURL)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "error getting code from local server: %v\n", err)
-				code = doOobFlow(&cfg, stateToken, opts)
-			}
-		}
+	if err := open.Run(authCodeURL); err != nil {
+		// Swap to the out of band flow if we can't open the browser
+		fmt.Fprintf(os.Stderr, "error opening browser: %v\n", err)
+		code = doOobFlow(&cfg, stateToken, opts)
 	} else {
-		// This code will only run in integration tests
-		page := rod.New().MustConnect().MustPage(authCodeURL)
-		page.MustElement("body > div.dex-container > div > div > div:nth-child(2) > a > button").MustClick()
-		code, _ = getCodeFromLocalServer(stateToken, redirectURL)
+		fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", authCodeURL)
+		code, err = getCodeFromLocalServer(stateToken, redirectURL)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error getting code from local server: %v\n", err)
+			code = doOobFlow(&cfg, stateToken, opts)
+		}
 	}
 	token, err := cfg.Exchange(context.Background(), code, append(pkce.TokenURLOpts(), oidc.Nonce(nonce))...)
 	if err != nil {

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -33,6 +33,6 @@ services:
     ports:
       - "5556:5556"
     volumes:
-      - ./oauthflow/dex-config.yml:/etc/dex/dex-config.yml:ro
+      - ./oauthflow/dex-config.yml:/etc/dex/dex-config.yml:z
     command: ["dex", "serve", "/etc/dex/dex-config.yml"]
 

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -28,3 +28,11 @@ services:
       - 4566:4566
     environment:
       - SERVICES=kms
+  dex:
+    image: ghcr.io/dexidp/dex:v2.30.0
+    ports:
+      - 5556:5556
+    volumes:
+      - ./oauthflow/dex-config.yml:/etc/dex/dex-config.yml:ro
+    command: ["serve", "/etc/dex/dex-config.yml"]
+

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -31,8 +31,8 @@ services:
   dex:
     image: ghcr.io/dexidp/dex:v2.30.0
     ports:
-      - 5556:5556
+      - "5556:5556"
     volumes:
       - ./oauthflow/dex-config.yml:/etc/dex/dex-config.yml:ro
-    command: ["serve", "/etc/dex/dex-config.yml"]
+    command: ["dex", "serve", "/etc/dex/dex-config.yml"]
 

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -62,6 +62,7 @@ export AWS_TLS_INSECURE_SKIP_VERIFY=1
 export OIDC_ISSUER=http://127.0.0.1:5556/auth
 export OIDC_ID=sigstore
 export OIDC_SECRET=mock-secret
+export INTEGRATION_TEST=1
 
 go test -tags e2e -count=1 ./...
 

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -61,7 +61,6 @@ export AWS_TLS_INSECURE_SKIP_VERIFY=1
 
 export OIDC_ISSUER=http://127.0.0.1:5556/auth
 export OIDC_ID=sigstore
-export OIDC_SECRET=mock-secret
 export INTEGRATION_TEST=1
 
 go test -tags e2e -count=1 ./...

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -61,7 +61,6 @@ export AWS_TLS_INSECURE_SKIP_VERIFY=1
 
 export OIDC_ISSUER=http://127.0.0.1:5556/auth
 export OIDC_ID=sigstore
-export INTEGRATION_TEST=1
 
 go test -tags e2e -count=1 ./...
 

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -59,6 +59,10 @@ export AWS_REGION=us-east-1
 export AWS_ENDPOINT=localhost:4566
 export AWS_TLS_INSECURE_SKIP_VERIFY=1
 
+export OIDC_ISSUER=http://localhost:5556/auth
+export OIDC_ID=sigstore
+export OIDC_SECRET=mock-secret
+
 go test -tags e2e -count=1 ./...
 
 cleanup

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -59,7 +59,7 @@ export AWS_REGION=us-east-1
 export AWS_ENDPOINT=localhost:4566
 export AWS_TLS_INSECURE_SKIP_VERIFY=1
 
-export OIDC_ISSUER=http://localhost:5556/auth
+export OIDC_ISSUER=http://127.0.0.1:5556/auth
 export OIDC_ID=sigstore
 export OIDC_SECRET=mock-secret
 

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -1,6 +1,18 @@
-# The base path of dex and the external name of the OpenID Connect service.
-# This is the canonical URL that all clients MUST use to refer to dex. If a
-# path is provided, dex's HTTP service will listen at a non-root URL.
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 issuer: http://127.0.0.1:5556/auth
 
 storage:

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -16,9 +16,7 @@
 issuer: http://127.0.0.1:5556/auth
 
 storage:
-  type: sqlite3
-  config:
-    file: /var/dex/dex.db
+  type: memory
 
 # Configuration for the HTTP endpoints.
 web:

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -44,12 +44,3 @@ connectors:
   id: mock
   name: Mock
 
-# A static list of passwords to login the end user. By identifying here, dex
-# won't look in its underlying storage for passwords.
-
-staticPasswords:
-- email: "admin@sigstore.dev"
-  # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
-  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-  username: "admin"
-  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -25,7 +25,7 @@ enablePasswordDB: true
 staticClients:
 - id: sigstore
   redirectURIs:
-  - 'http://127.0.0.1:5555/callback'
+  - 'http://localhost:5555/auth/callback'
   name: 'Sigstore Mock'
   secret: mock-secret
 

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -6,7 +6,7 @@ issuer: http://127.0.0.1:5556/auth
 storage:
   type: sqlite3
   config:
-    file: ./dex.db
+    file: /var/dex/dex.db
 
 # Configuration for the HTTP endpoints.
 web:
@@ -19,6 +19,8 @@ oauth2:
   responseTypes: [ "code" ]
   skipApprovalScreen: true
   alwaysShowLoginScreen: false
+
+enablePasswordDB: true
 
 staticClients:
 - id: sigstore

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -30,12 +30,8 @@ oauth2:
   skipApprovalScreen: true
   alwaysShowLoginScreen: false
 
-enablePasswordDB: true
-
 staticClients:
 - id: sigstore
-  redirectURIs:
-  - 'http://localhost:5557/auth/callback'
   name: 'Sigstore Mock'
   public: true
 

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -1,0 +1,47 @@
+# DEPRECATED: use config.yaml.dist and config.dev.yaml examples in the repository root.
+# TODO: keep this until all references are updated.
+
+# The base path of dex and the external name of the OpenID Connect service.
+# This is the canonical URL that all clients MUST use to refer to dex. If a
+# path is provided, dex's HTTP service will listen at a non-root URL.
+issuer: http://127.0.0.1:5556/auth
+
+storage:
+  type: sqlite3
+  config:
+    file: examples/dex.db
+
+# Configuration for the HTTP endpoints.
+web:
+  http: 0.0.0.0:5556
+
+logger:
+  level: debug
+
+oauth2:
+  responseTypes: [ "code" ]
+  skipApprovalScreen: true
+  alwaysShowLoginScreen: false
+
+staticClients:
+- id: sigstore
+  redirectURIs:
+  - 'http://127.0.0.1:5555/auth/callback'
+  name: 'Sigstore Mock'
+  secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+
+connectors:
+- type: mockCallback
+  id: mock
+  name: Mock
+
+# A static list of passwords to login the end user. By identifying here, dex
+# won't look in its underlying storage for passwords.
+#
+# If this option isn't chosen users may be added through the gRPC API.
+staticPasswords:
+- email: "admin@example.com"
+  # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
+  hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+  username: "admin"
+  userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -37,7 +37,7 @@ staticClients:
   redirectURIs:
   - 'http://localhost:5557/auth/callback'
   name: 'Sigstore Mock'
-  secret: mock-secret
+  public: true
 
 connectors:
 - type: mockCallback

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -37,7 +37,7 @@ enablePasswordDB: true
 staticClients:
 - id: sigstore
   redirectURIs:
-  - 'http://localhost:5555/auth/callback'
+  - 'http://localhost:5557/auth/callback'
   name: 'Sigstore Mock'
   secret: mock-secret
 

--- a/test/e2e/oauthflow/dex-config.yml
+++ b/test/e2e/oauthflow/dex-config.yml
@@ -1,6 +1,3 @@
-# DEPRECATED: use config.yaml.dist and config.dev.yaml examples in the repository root.
-# TODO: keep this until all references are updated.
-
 # The base path of dex and the external name of the OpenID Connect service.
 # This is the canonical URL that all clients MUST use to refer to dex. If a
 # path is provided, dex's HTTP service will listen at a non-root URL.
@@ -9,7 +6,7 @@ issuer: http://127.0.0.1:5556/auth
 storage:
   type: sqlite3
   config:
-    file: examples/dex.db
+    file: ./dex.db
 
 # Configuration for the HTTP endpoints.
 web:
@@ -26,9 +23,9 @@ oauth2:
 staticClients:
 - id: sigstore
   redirectURIs:
-  - 'http://127.0.0.1:5555/auth/callback'
+  - 'http://127.0.0.1:5555/callback'
   name: 'Sigstore Mock'
-  secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+  secret: mock-secret
 
 connectors:
 - type: mockCallback
@@ -37,10 +34,9 @@ connectors:
 
 # A static list of passwords to login the end user. By identifying here, dex
 # won't look in its underlying storage for passwords.
-#
-# If this option isn't chosen users may be added through the gRPC API.
+
 staticPasswords:
-- email: "admin@example.com"
+- email: "admin@sigstore.dev"
   # bcrypt hash of the string "password": $(echo password | htpasswd -BinC 10 admin | cut -d: -f2)
   hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
   username: "admin"

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -18,11 +18,12 @@
 package oauthflow
 
 import (
+	"os"
+	"testing"
+
 	"github.com/sigstore/sigstore/pkg/oauthflow"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
 )
 
 type OAuthSuite struct {
@@ -47,4 +48,3 @@ func (suite *OAuthSuite) TestOauthFlow() {
 func TestVault(t *testing.T) {
 	suite.Run(t, new(OAuthSuite))
 }
-

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -18,6 +18,7 @@
 package oauthflow
 
 import (
+	"os"
 	"testing"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -30,9 +31,9 @@ type OAuthSuite struct {
 
 func (suite *OAuthSuite) TestOauthFlow() {
 	idToken, err := oauthflow.OIDConnect(
-		"http://127.0.0.1:5556/auth",
-		"sigstore",
-		"mock-secret",
+		os.Getenv("OIDC_ISSUER"),
+		os.Getenv("OIDC_ID"),
+		os.Getenv("OIDC_SECRET"),
 		oauthflow.DefaultIDTokenGetter,
 	)
 

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -1,0 +1,45 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build e2e
+
+package oauthflow
+
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/sigstore/sigstore/pkg/oauthflow"
+)
+
+type OAuthSuite struct {
+	suite.Suite
+}
+
+func (suite *OAuthSuite) TestOauthFlow() {
+	idToken, err := oauthflow.OIDConnect(
+		"http://127.0.0.1:5556/auth",
+		"sigstore",
+		"ZXhhbXBsZS1hcHAtc2VjcmV0",
+		oauthflow.DefaultIDTokenGetter,
+	)
+	require.Nil(suite.T(), err)
+	require.NotNil(suite.T(), idToken)
+}
+
+func TestVault(t *testing.T) {
+	suite.Run(t, new(OAuthSuite))
+}
+

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -18,11 +18,12 @@
 package oauthflow
 
 import (
-	"os"
-	"testing"
+	"fmt"
+	"github.com/sigstore/sigstore/pkg/oauthflow"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/sigstore/sigstore/pkg/oauthflow"
+	"os"
+	"testing"
 )
 
 type OAuthSuite struct {
@@ -37,6 +38,8 @@ func (suite *OAuthSuite) TestOauthFlow() {
 		oauthflow.DefaultIDTokenGetter,
 	)
 
+	code := idToken.Subject
+	fmt.Println("subject", code)
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), idToken)
 }

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -52,7 +52,7 @@ func (suite *OAuthSuite) TestOauthFlow() {
 	idToken, err := oauthflow.OIDConnect(
 		os.Getenv("OIDC_ISSUER"),
 		os.Getenv("OIDC_ID"),
-		os.Getenv("OIDC_SECRET"),
+		"",
 		oauthflow.DefaultIDTokenGetter,
 	)
 

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -45,6 +45,6 @@ func (suite *OAuthSuite) TestOauthFlow() {
 	require.Equal(suite.T(), "kilgore@kilgore.trout", email)
 }
 
-func TestVault(t *testing.T) {
+func TestOAuthFlow(t *testing.T) {
 	suite.Run(t, new(OAuthSuite))
 }

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -32,9 +32,10 @@ func (suite *OAuthSuite) TestOauthFlow() {
 	idToken, err := oauthflow.OIDConnect(
 		"http://127.0.0.1:5556/auth",
 		"sigstore",
-		"ZXhhbXBsZS1hcHAtc2VjcmV0",
+		"mock-secret",
 		oauthflow.DefaultIDTokenGetter,
 	)
+
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), idToken)
 }

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -18,7 +18,6 @@
 package oauthflow
 
 import (
-	"fmt"
 	"github.com/sigstore/sigstore/pkg/oauthflow"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -38,10 +37,11 @@ func (suite *OAuthSuite) TestOauthFlow() {
 		oauthflow.DefaultIDTokenGetter,
 	)
 
-	code := idToken.Subject
-	fmt.Println("subject", code)
+	email := idToken.Subject
+
 	require.Nil(suite.T(), err)
-	require.NotNil(suite.T(), idToken)
+	require.NotNil(suite.T(), email)
+	require.Equal(suite.T(), "kilgore@kilgore.trout", email)
 }
 
 func TestVault(t *testing.T) {

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -38,9 +38,9 @@ func (suite *OAuthSuite) TestOauthFlow() {
 		oauthflow.DefaultIDTokenGetter,
 	)
 
-	email := idToken.Subject
-
 	require.Nil(suite.T(), err)
+
+	email := idToken.Subject
 	require.NotNil(suite.T(), email)
 	require.Equal(suite.T(), "kilgore@kilgore.trout", email)
 }


### PR DESCRIPTION
Add the OpenID flow sequence as an integration test. This allows us to test the flow, including the browser grant request.

Signed-off-by: Luke Hinds <lhinds@redhat.com>
