### PR TITLE
Pin localstack in e2e tests (fixes #112)

### DIFF
--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - 8200:8200
     privileged: true
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:0.12.16
     ports:
       - 4566:4566
     environment:


### PR DESCRIPTION
#### Summary

e2e tests are failing due to a localstack bug. (`localstack/localstack:latest` actually reflects localstack's master branch, not latest release). This pins to a release that is known to work.

#### Ticket Link

Fixes #112 

#### Release Note

```release-note
NONE
```
