### PR TITLE
Split CI tests according to job type

### DIFF
--- a/.github/workflows/build_test_lint.yml
+++ b/.github/workflows/build_test_lint.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Go
+name: build_test_lint
 
 permissions:
   contents: read
@@ -25,7 +25,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: 1.16.6
+  GO_VERSION: 1.17
 
 jobs:
   build:
@@ -60,43 +60,3 @@ jobs:
 
     - name: Ensure no files were modified as a result of the build
       run: git update-index --refresh && git diff-index --quiet HEAD -- || git diff --exit-code
-
-  e2e:
-    runs-on: ubuntu-latest
-    needs: [build]
-    services:
-      vault:
-        image: vault
-        env:
-          VAULT_DEV_ROOT_TOKEN_ID: testtoken
-        ports:
-        - 8200/tcp
-      localstack:
-        image: localstack/localstack:0.12.15
-        ports:
-        - 4566/tcp
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ env.GO_VERSION }}
-    - name: Cache Modules
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Test
-      env:
-        VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
-        VAULT_TOKEN: testtoken
-        AWS_ACCESS_KEY_ID: test
-        AWS_SECRET_ACCESS_KEY: test
-        AWS_REGION: us-east-1
-        AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
-        AWS_TLS_INSECURE_SKIP_VERIFY: 1
-      run: go test -tags e2e -v ./test/e2e/...

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -1,0 +1,66 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: e2e_tests
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  e2e_tests:
+      runs-on: ubuntu-latest
+      needs: [build]
+      services:
+        vault:
+          image: vault
+          env:
+            VAULT_DEV_ROOT_TOKEN_ID: testtoken
+          ports:
+          - 8200/tcp
+        localstack:
+          image: localstack/localstack:0.12.15
+          ports:
+          - 4566/tcp
+      steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Cache Modules
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Test
+        env:
+          VAULT_ADDR: http://localhost:${{ job.services.vault.ports[8200] }}
+          VAULT_TOKEN: testtoken
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_REGION: us-east-1
+          AWS_ENDPOINT: localhost:${{ job.services.localstack.ports[4566] }}
+          AWS_TLS_INSECURE_SKIP_VERIFY: 1
+        run: go test -tags e2e -v ./test/e2e/...

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Verify
+name: license_check
 
 on:
   push:
@@ -22,7 +22,7 @@ on:
     branches: [ main ]
 
 jobs:
-  license-check:
+  license_check:
     name: license boilerplate check
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This refactors the tests into more modular parts that will make
it easier for a commiter to read and process.

Signed-off-by: Luke Hinds <luke@redhat.com>
