### PR TITLE
Idp specific default flows

### DIFF
--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -37,9 +37,10 @@ const (
 </html>
 `
 
-	GithubAuthSubURL    = "https://github.com/login/oauth"
-	GoogleAuthSubURL    = "https://accounts.google.com"
-	MicrosoftAuthSubURL = "https://login.microsoftonline.com"
+	// Default connector ids used by `oauth2.sigstore.dev` for specfic Idps.
+	PublicInstanceGithubAuthSubURL    = "https://github.com/login/oauth"
+	PublicInstanceGoogleAuthSubURL    = "https://accounts.google.com"
+	PublicInstanceMicrosoftAuthSubURL = "https://login.microsoftonline.com"
 )
 
 type TokenGetter interface {
@@ -62,22 +63,28 @@ var DefaultIDTokenGetter = &InteractiveIDTokenGetter{
 	HTMLPage:       htmlPage,
 }
 
+// DefaultGithubIDTokenGetter is a `oauth2.sigstore.dev` flow selecting github as an Idp
+// Flow is based on `DefaultIDTokenGetter` fields
 var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
-	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GithubAuthSubURL)},
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(PublicInstanceGithubAuthSubURL)},
 }
 
+// DefaultGoogleIDTokenGetter is a `oauth2.sigstore.dev` flow selecting github as an Idp
+// Flow is based on `DefaultIDTokenGetter` fields
 var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
-	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GoogleAuthSubURL)},
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(PublicInstanceGoogleAuthSubURL)},
 }
 
+// DefaultMicrosoftIDTokenGetter is a `oauth2.sigstore.dev` flow selecting microsoft as an Idp
+// Flow is based on `DefaultIDTokenGetter` fields
 var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
-	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(MicrosoftAuthSubURL)},
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(PublicInstanceMicrosoftAuthSubURL)},
 }
 
 func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -57,26 +57,26 @@ var DefaultIDTokenGetter = &InteractiveIDTokenGetter{
 	HTMLPage:       htmlPage,
 }
 
-func ConnectorIdOpt(prov string) oauth2.AuthCodeOption {
+func ConnectorIDOpt(prov string) oauth2.AuthCodeOption {
 	return oauth2.SetAuthURLParam("connector_id", prov)
 }
 
 var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIdOpt(GithubAuthSubURL)},
+	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIDOpt(GithubAuthSubURL)},
 }
 
 var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIdOpt(GoogleAuthSubURL)},
+	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIDOpt(GoogleAuthSubURL)},
 }
 
 var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIdOpt(MicrosoftAuthSubURL)},
+	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIDOpt(MicrosoftAuthSubURL)},
 }
 
 func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -37,7 +37,7 @@ const (
 </html>
 `
 
-	// Default connector ids used by `oauth2.sigstore.dev` for specfic Idps.
+	// Default connector ids used by `oauth2.sigstore.dev` for specific Idps.
 	PublicInstanceGithubAuthSubURL    = "https://github.com/login/oauth"
 	PublicInstanceGoogleAuthSubURL    = "https://accounts.google.com"
 	PublicInstanceMicrosoftAuthSubURL = "https://login.microsoftonline.com"

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -27,7 +27,8 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-const htmlPage = `<html>
+const (
+	htmlPage = `<html>
 <title>Sigstore Auth</title>
 <body>
 <h1>Sigstore Auth Successful</h1>
@@ -35,6 +36,11 @@ const htmlPage = `<html>
 </body>
 </html>
 `
+
+	GithubAuthSubURL    = "https://github.com/login/oauth"
+	GoogleAuthSubURL    = "https://accounts.google.com"
+	MicrosoftAuthSubURL = "https://login.microsoftonline.com"
+)
 
 type TokenGetter interface {
 	GetIDToken(provider *oidc.Provider, config oauth2.Config) (*OIDCIDToken, error)
@@ -45,11 +51,33 @@ type OIDCIDToken struct {
 	Subject   string
 }
 
+func ConnectorIDOpt(prov string) oauth2.AuthCodeOption {
+	return oauth2.SetAuthURLParam("connector_id", prov)
+}
+
 // DefaultIDTokenGetter is the default implementation.
 // The HTML page and message printed to the terminal can be customized.
 var DefaultIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: func(url string) { fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", url) },
 	HTMLPage:       htmlPage,
+}
+
+var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
+	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GithubAuthSubURL)},
+}
+
+var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
+	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GoogleAuthSubURL)},
+}
+
+var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
+	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(MicrosoftAuthSubURL)},
 }
 
 func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -63,25 +63,25 @@ var DefaultIDTokenGetter = &InteractiveIDTokenGetter{
 	HTMLPage:       htmlPage,
 }
 
-// DefaultGithubIDTokenGetter is a `oauth2.sigstore.dev` flow selecting github as an Idp
+// PublicInstanceGithubIDTokenGetter is a `oauth2.sigstore.dev` flow selecting github as an Idp
 // Flow is based on `DefaultIDTokenGetter` fields
-var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
+var PublicInstanceGithubIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
 	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(PublicInstanceGithubAuthSubURL)},
 }
 
-// DefaultGoogleIDTokenGetter is a `oauth2.sigstore.dev` flow selecting github as an Idp
+// PublicInstanceGoogleIDTokenGetter is a `oauth2.sigstore.dev` flow selecting github as an Idp
 // Flow is based on `DefaultIDTokenGetter` fields
-var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
+var PublicInstanceGoogleIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
 	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(PublicInstanceGoogleAuthSubURL)},
 }
 
-// DefaultMicrosoftIDTokenGetter is a `oauth2.sigstore.dev` flow selecting microsoft as an Idp
+// PublicInstanceMicrosoftIDTokenGetter is a `oauth2.sigstore.dev` flow selecting microsoft as an Idp
 // Flow is based on `DefaultIDTokenGetter` fields
-var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
+var PublicInstanceMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
 	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(PublicInstanceMicrosoftAuthSubURL)},

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -27,8 +27,7 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-const (
-	htmlPage = `<html>
+const htmlPage = `<html>
 <title>Sigstore Auth</title>
 <body>
 <h1>Sigstore Auth Successful</h1>
@@ -36,10 +35,6 @@ const (
 </body>
 </html>
 `
-	GithubAuthSubURL    = "github-sigstore-prod"
-	GoogleAuthSubURL    = "google-sigstore-prod"
-	MicrosoftAuthSubURL = "microsoft-sigstore-prod"
-)
 
 type TokenGetter interface {
 	GetIDToken(provider *oidc.Provider, config oauth2.Config) (*OIDCIDToken, error)
@@ -55,28 +50,6 @@ type OIDCIDToken struct {
 var DefaultIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: func(url string) { fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", url) },
 	HTMLPage:       htmlPage,
-}
-
-func ConnectorIDOpt(prov string) oauth2.AuthCodeOption {
-	return oauth2.SetAuthURLParam("connector_id", prov)
-}
-
-var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
-	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
-	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
-	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GithubAuthSubURL)},
-}
-
-var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
-	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
-	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
-	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GoogleAuthSubURL)},
-}
-
-var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
-	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
-	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
-	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(MicrosoftAuthSubURL)},
 }
 
 func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -27,7 +27,8 @@ import (
 	"gopkg.in/square/go-jose.v2"
 )
 
-const htmlPage = `<html>
+const (
+	htmlPage = `<html>
 <title>Sigstore Auth</title>
 <body>
 <h1>Sigstore Auth Successful</h1>
@@ -35,6 +36,10 @@ const htmlPage = `<html>
 </body>
 </html>
 `
+	GithubAuthSubURL    = "github-sigstore-prod"
+	GoogleAuthSubURL    = "google-sigstore-prod"
+	MicrosoftAuthSubURL = "microsoft-sigstore-prod"
+)
 
 type TokenGetter interface {
 	GetIDToken(provider *oidc.Provider, config oauth2.Config) (*OIDCIDToken, error)
@@ -50,6 +55,24 @@ type OIDCIDToken struct {
 var DefaultIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: func(url string) { fmt.Fprintf(os.Stderr, "Your browser will now be opened to:\n%s\n", url) },
 	HTMLPage:       htmlPage,
+}
+
+var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
+	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
+	AuthSubURL:     GithubAuthSubURL,
+}
+
+var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
+	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
+	AuthSubURL:     GoogleAuthSubURL,
+}
+
+var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
+	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
+	AuthSubURL:     MicrosoftAuthSubURL,
 }
 
 func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -62,21 +62,21 @@ func ConnectorIDOpt(prov string) oauth2.AuthCodeOption {
 }
 
 var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
-	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
-	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIDOpt(GithubAuthSubURL)},
+	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GithubAuthSubURL)},
 }
 
 var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
-	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
-	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIDOpt(GoogleAuthSubURL)},
+	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(GoogleAuthSubURL)},
 }
 
 var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
-	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
-	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIDOpt(MicrosoftAuthSubURL)},
+	MessagePrinter:     DefaultIDTokenGetter.MessagePrinter,
+	HTMLPage:           DefaultIDTokenGetter.HTMLPage,
+	ExtraAuthURLParams: []oauth2.AuthCodeOption{ConnectorIDOpt(MicrosoftAuthSubURL)},
 }
 
 func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -57,22 +57,26 @@ var DefaultIDTokenGetter = &InteractiveIDTokenGetter{
 	HTMLPage:       htmlPage,
 }
 
+func ConnectorIdOpt(prov string) oauth2.AuthCodeOption {
+	return oauth2.SetAuthURLParam("connector_id", prov)
+}
+
 var DefaultGithubIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	AuthSubURL:     GithubAuthSubURL,
+	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIdOpt(GithubAuthSubURL)},
 }
 
 var DefaultGoogleIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	AuthSubURL:     GoogleAuthSubURL,
+	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIdOpt(GoogleAuthSubURL)},
 }
 
 var DefaultMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
 	MessagePrinter: DefaultIDTokenGetter.MessagePrinter,
 	HTMLPage:       DefaultIDTokenGetter.HTMLPage,
-	AuthSubURL:     MicrosoftAuthSubURL,
+	ExtraOpt:       []oauth2.AuthCodeOption{ConnectorIdOpt(MicrosoftAuthSubURL)},
 }
 
 func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -36,9 +36,9 @@ const oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
 
 // InteractiveIDTokenGetter is a type to get ID tokens for oauth flows
 type InteractiveIDTokenGetter struct {
-	MessagePrinter func(url string)
-	HTMLPage       string
-	ExtraOpt       []oauth2.AuthCodeOption
+	MessagePrinter     func(url string)
+	HTMLPage           string
+	ExtraAuthURLParams []oauth2.AuthCodeOption
 }
 
 func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) (*OIDCIDToken, error) {
@@ -68,8 +68,8 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 	}
 
 	opts := append(pkce.AuthURLOpts(), oauth2.AccessTypeOnline, oidc.Nonce(nonce))
-	if len(i.ExtraOpt) > 0 {
-		opts = append(opts, i.ExtraOpt...)
+	if len(i.ExtraAuthURLParams) > 0 {
+		opts = append(opts, i.ExtraAuthURLParams...)
 	}
 	authCodeURL := cfg.AuthCodeURL(stateToken, opts...)
 	var code string

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -38,6 +39,7 @@ const oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
 type InteractiveIDTokenGetter struct {
 	MessagePrinter func(url string)
 	HTMLPage       string
+	AuthSubURL     string
 }
 
 func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) (*OIDCIDToken, error) {
@@ -59,6 +61,9 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 	}()
 
 	cfg.RedirectURL = redirectURL.String()
+	if i.AuthSubURL != "" {
+		cfg.Endpoint.AuthURL = path.Join(cfg.Endpoint.AuthURL, i.AuthSubURL)
+	}
 
 	// require that OIDC provider support PKCE to provide sufficient security for the CLI
 	pkce, err := NewPKCE(p)


### PR DESCRIPTION
Suggestion:
Adding interactive flows for each specific  identity provider, allowing users to skip the main idp selection page.
I think one less click can improve the UX a bit.
Further UX improvement is gained when browser uses a default idp account the user does may not need to interactively intervene at all.
Such psodo-auto flow may also be valuable in automation uses cases, for example a git hook signing SLSA  provenance.

Hope this helps .
mikey strauss