### PR TITLE
Make SimpleContainerImage struct accesible for tekton chains

### DIFF
--- a/pkg/signature/payload/payload.go
+++ b/pkg/signature/payload/payload.go
@@ -51,8 +51,8 @@ type Cosign struct {
 	Annotations map[string]interface{}
 }
 
-func (p Cosign) MarshalJSON() ([]byte, error) {
-	simple := SimpleContainerImage{
+func (p Cosign) SimpleContainerImage() SimpleContainerImage {
+	return SimpleContainerImage{
 		Critical: Critical{
 			Identity: Identity{
 				DockerReference: p.Image.Repository.Name(),
@@ -64,7 +64,10 @@ func (p Cosign) MarshalJSON() ([]byte, error) {
 		},
 		Optional: p.Annotations,
 	}
-	return json.Marshal(simple)
+}
+
+func (p Cosign) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.SimpleContainerImage())
 }
 
 var _ json.Marshaler = Cosign{}


### PR DESCRIPTION
Right now Chains is using its own custom `SimpleSigning` struct for container images, which is marshaling JSON differently from how cosign does it. I want to copy cosign and use this library in chains as well, exposing this function should make it easier to implement.

Signed-off-by: Priya Wadhwa <priyawadhwa@google.com>



-->
```release-note
NONE
```
