### PR TITLE
Fix the azure KMS provider

### DIFF
--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -217,13 +216,11 @@ func (a *azureVaultClient) createKey(ctx context.Context) (crypto.PublicKey, err
 	return a.public()
 }
 
-func (a *azureVaultClient) sign(ctx context.Context, rawPayload []byte) ([]byte, error) {
-	hash := sha256.Sum256(rawPayload)
-	signed := hash[:]
+func (a *azureVaultClient) sign(ctx context.Context, hash []byte) ([]byte, error) {
 
 	params := keyvault.KeySignParameters{
 		Algorithm: keyvault.ES256,
-		Value:     to.StringPtr(base64.RawURLEncoding.EncodeToString(signed)),
+		Value:     to.StringPtr(base64.RawURLEncoding.EncodeToString(hash)),
 	}
 
 	result, err := a.client.Sign(ctx, a.vaultURL, a.keyName, "", params)
@@ -239,13 +236,11 @@ func (a *azureVaultClient) sign(ctx context.Context, rawPayload []byte) ([]byte,
 	return decResult, nil
 }
 
-func (a *azureVaultClient) verify(ctx context.Context, signature, payload []byte) error {
-	hash := sha256.Sum256(payload)
-	signed := hash[:]
+func (a *azureVaultClient) verify(ctx context.Context, signature, hash []byte) error {
 
 	params := keyvault.KeyVerifyParameters{
 		Algorithm: keyvault.ES256,
-		Digest:    to.StringPtr(base64.RawURLEncoding.EncodeToString(signed)),
+		Digest:    to.StringPtr(base64.RawURLEncoding.EncodeToString(hash)),
 		Signature: to.StringPtr(base64.RawURLEncoding.EncodeToString(signature)),
 	}
 


### PR DESCRIPTION
There were two issues: double hashing and the wrong signature formats.

We already hash the contents in SignMessage using a configurable
hash function, so we don't need this one here.

The other issue was caused by azure returning and expecting a raw byte sequence
of R||S concatenated, rather than an ASN.1 sequence. Big thanks to mwielgoszewski
for providing the tips and POC.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
