### PR TITLE
Clean up lint errors

### DIFF
--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	// CertificatePEMType is the string "CERTIFICATE" to be used during PEM encoding and decoding
 	CertificatePEMType PEMType = "CERTIFICATE"
 )
 
@@ -73,7 +74,7 @@ func UnmarshalCertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) 
 	return result, nil
 }
 
-// LoadCertificatesFromPEMFile extracts one or more X509 certificates from the provided
+// LoadCertificatesFromPEM extracts one or more X509 certificates from the provided
 // io.Reader.
 func LoadCertificatesFromPEM(pem io.Reader) ([]*x509.Certificate, error) {
 	fileBytes, err := io.ReadAll(pem)

--- a/pkg/cryptoutils/generic.go
+++ b/pkg/cryptoutils/generic.go
@@ -19,8 +19,10 @@ import (
 	"encoding/pem"
 )
 
+// PEMType is a specific type for string constants used during PEM encoding and decoding
 type PEMType string
 
+// PEMEncode encodes the specified byte slice in PEM format using the provided type string
 func PEMEncode(typeStr PEMType, bytes []byte) []byte {
 	return pem.EncodeToMemory(&pem.Block{
 		Type:  string(typeStr),

--- a/pkg/cryptoutils/password.go
+++ b/pkg/cryptoutils/password.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/term"
 )
 
+// PassFunc is a type of function that takes a boolean (representing whether confirmation is desired) and returns the password as read, along with an error if one occurred
 type PassFunc func(bool) ([]byte, error)
 
 var (

--- a/pkg/cryptoutils/privatekey.go
+++ b/pkg/cryptoutils/privatekey.go
@@ -30,8 +30,10 @@ import (
 )
 
 const (
-	PrivateKeyPEMType                  PEMType = "PRIVATE KEY"
-	encryptedCosignPrivateKeyPEMType   PEMType = "ENCRYPTED COSIGN PRIVATE KEY"
+	// PrivateKeyPEMType is the string "PRIVATE KEY" to be used during PEM encoding and decoding
+	PrivateKeyPEMType                PEMType = "PRIVATE KEY"
+	encryptedCosignPrivateKeyPEMType PEMType = "ENCRYPTED COSIGN PRIVATE KEY"
+	// EncryptedSigstorePrivateKeyPEMType is the string "ENCRYPTED SIGSTORE PRIVATE KEY" to be used during PEM encoding and decoding
 	EncryptedSigstorePrivateKeyPEMType PEMType = "ENCRYPTED SIGSTORE PRIVATE KEY"
 )
 
@@ -79,6 +81,7 @@ func GeneratePEMEncodedRSAKeyPair(keyLengthBits int, pf PassFunc) (privPEM, pubP
 	return pemEncodeKeyPair(priv, priv.Public(), pf)
 }
 
+// MarshalPrivateKeyToEncryptedDER marshals the private key and encrypts the DER-encoded value using the specified password function
 func MarshalPrivateKeyToEncryptedDER(priv crypto.PrivateKey, pf PassFunc) ([]byte, error) {
 	derKey, err := MarshalPrivateKeyToDER(priv)
 	if err != nil {

--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	// PublicKeyPEMType is the string "PUBLIC KEY" to be used during PEM encoding and decoding
 	PublicKeyPEMType PEMType = "PUBLIC KEY"
 )
 

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -29,8 +29,10 @@ import (
 )
 
 const (
+	// SigstoreDeviceURL specifies the Device Code endpoint for the public good Sigstore service
 	/* #nosec */
 	SigstoreDeviceURL = "https://oauth2.sigstore.dev/auth/device/code"
+	// SigstoreTokenURL specifies the Token endpoint for the public good Sigstore service
 	/* #nosec */
 	SigstoreTokenURL = "https://oauth2.sigstore.dev/auth/device/token"
 )
@@ -49,6 +51,7 @@ type tokenResp struct {
 	Error   string `json:"error"`
 }
 
+// DeviceFlowTokenGetter fetches an OIDC Identity token using the Device Code Grant flow as specified in RFC8628
 type DeviceFlowTokenGetter struct {
 	MessagePrinter func(string)
 	Sleeper        func(time.Duration)
@@ -57,6 +60,7 @@ type DeviceFlowTokenGetter struct {
 	TokenURL       string
 }
 
+// NewDeviceFlowTokenGetter creates a new DeviceFlowTokenGetter that retrieves an OIDC Identity Token using a Device Code Grant
 func NewDeviceFlowTokenGetter(issuer, codeURL, tokenURL string) *DeviceFlowTokenGetter {
 	return &DeviceFlowTokenGetter{
 		MessagePrinter: func(s string) { fmt.Println(s) },
@@ -134,6 +138,7 @@ func (d *DeviceFlowTokenGetter) deviceFlow(clientID string) (string, error) {
 	}
 }
 
+// GetIDToken gets an OIDC ID Token from the specified provider using the device code grant flow
 func (d *DeviceFlowTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) (*OIDCIDToken, error) {
 	idToken, err := d.deviceFlow(cfg.ClientID)
 	if err != nil {

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -41,6 +41,7 @@ type InteractiveIDTokenGetter struct {
 	ExtraAuthURLParams []oauth2.AuthCodeOption
 }
 
+// GetIDToken gets an OIDC ID Token from the specified provider using an interactive browser session
 func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) (*OIDCIDToken, error) {
 	// generate random fields and save them for comparison after OAuth2 dance
 	stateToken := randStr()

--- a/pkg/oauthflow/pkce.go
+++ b/pkg/oauthflow/pkce.go
@@ -25,15 +25,18 @@ import (
 )
 
 const (
+	// PKCES256 is the SHA256 option required by the PKCE RFC
 	PKCES256 = "S256"
 )
 
+// PKCE specifies the challenge and value pair required to fulfill RFC7636
 type PKCE struct {
 	Challenge string
 	Method    string
 	Value     string
 }
 
+// NewPKCE creates a new PKCE challenge for the specified provider per its supported methods (obtained through OIDC discovery endpoint)
 func NewPKCE(provider *oidc.Provider) (*PKCE, error) {
 	var providerClaims struct {
 		CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
@@ -73,6 +76,7 @@ func NewPKCE(provider *oidc.Provider) (*PKCE, error) {
 	}, nil
 }
 
+// AuthURLOpts returns the set of request parameters required during the initial exchange of the OAuth2 flow
 func (p *PKCE) AuthURLOpts() []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("code_challenge_method", string(p.Method)),
@@ -80,6 +84,7 @@ func (p *PKCE) AuthURLOpts() []oauth2.AuthCodeOption {
 	}
 }
 
+// TokenURLOpts returns the set of request parameters required during the token request exchange flow
 func (p *PKCE) TokenURLOpts() []oauth2.AuthCodeOption {
 	return []oauth2.AuthCodeOption{
 		oauth2.SetAuthURLParam("code_verifier", p.Value),

--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -34,6 +34,7 @@ var ecdsaSupportedHashFuncs = []crypto.Hash{
 	crypto.SHA1,
 }
 
+// ECDSASigner is a signature.Signer that uses an Elliptic Curve DSA algorithm
 type ECDSASigner struct {
 	hashFunc crypto.Hash
 	priv     *ecdsa.PrivateKey
@@ -112,6 +113,7 @@ func (e ECDSASigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts)
 	return e.SignMessage(nil, ecdsaOpts...)
 }
 
+// ECDSAVerifier is a signature.Verifier that uses an Elliptic Curve DSA algorithm
 type ECDSAVerifier struct {
 	publicKey *ecdsa.PublicKey
 	hashFunc  crypto.Hash
@@ -171,6 +173,7 @@ func (e ECDSAVerifier) VerifySignature(signature, message io.Reader, opts ...Ver
 	return nil
 }
 
+// ECDSASignerVerifier is a signature.SignerVerifier that uses an Elliptic Curve DSA algorithm
 type ECDSASignerVerifier struct {
 	*ECDSASigner
 	*ECDSAVerifier

--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -29,6 +29,7 @@ var ed25519SupportedHashFuncs = []crypto.Hash{
 	crypto.Hash(0),
 }
 
+// ED25519Signer is a signature.Signer that uses the Ed25519 public-key signature system
 type ED25519Signer struct {
 	priv ed25519.PrivateKey
 }
@@ -89,6 +90,7 @@ func (e ED25519Signer) Sign(_ io.Reader, message []byte, _ crypto.SignerOpts) ([
 	return e.SignMessage(bytes.NewReader(message))
 }
 
+// ED25519Verifier is a signature.Verifier that uses the Ed25519 public-key signature system
 type ED25519Verifier struct {
 	publicKey ed25519.PublicKey
 }
@@ -137,6 +139,7 @@ func (e *ED25519Verifier) VerifySignature(signature, message io.Reader, _ ...Ver
 	return nil
 }
 
+// ED25519SignerVerifier is a signature.SignerVerifier that uses the Ed25519 public-key signature system
 type ED25519SignerVerifier struct {
 	*ED25519Signer
 	*ED25519Verifier
@@ -163,7 +166,7 @@ func LoadED25519SignerVerifier(priv ed25519.PrivateKey) (*ED25519SignerVerifier,
 
 // NewDefaultED25519SignerVerifier creates a combined signer and verifier using ED25519.
 // This creates a new ED25519 key using crypto/rand as an entropy source.
-func NewDefaultED25519SignerVerifierE() (*ED25519SignerVerifier, ed25519.PrivateKey, error) {
+func NewDefaultED25519SignerVerifier() (*ED25519SignerVerifier, ed25519.PrivateKey, error) {
 	return NewED25519SignerVerifier(rand.Reader)
 }
 

--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -51,10 +51,12 @@ var (
 )
 
 const (
+	// ReferenceScheme schemes for various KMS services are copied from https://github.com/google/go-cloud/tree/master/secrets
 	ReferenceScheme = "azurekms://"
-	CacheKey        = "azure_vault_signer"
+	cacheKey        = "azure_vault_signer"
 )
 
+// ValidReference returns a non-nil error if the reference string is invalid
 func ValidReference(ref string) error {
 	if !referenceRegex.MatchString(ref) {
 		return errAzureReference
@@ -182,7 +184,7 @@ func (a *azureVaultClient) getKey(ctx context.Context) (keyvault.KeyBundle, erro
 }
 
 func (a *azureVaultClient) public() (crypto.PublicKey, error) {
-	return a.keyCache.Get(CacheKey)
+	return a.keyCache.Get(cacheKey)
 }
 
 func (a *azureVaultClient) createKey(ctx context.Context) (crypto.PublicKey, error) {

--- a/pkg/signature/kms/gcp/signer.go
+++ b/pkg/signature/kms/gcp/signer.go
@@ -16,7 +16,6 @@
 package gcp
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"hash/crc32"
@@ -33,6 +32,7 @@ var gcpSupportedHashFuncs = []crypto.Hash{
 	crypto.SHA384,
 }
 
+// SignerVerifier creates and verifies digital signatures over a message using GCP KMS service
 type SignerVerifier struct {
 	defaultCtx context.Context
 	client     *gcpClient
@@ -53,12 +53,6 @@ func LoadSignerVerifier(defaultCtx context.Context, referenceStr string) (*Signe
 	}
 
 	return g, nil
-}
-
-// THIS WILL BE REMOVED ONCE ALL SIGSTORE PROJECTS NO LONGER USE IT
-func (g *SignerVerifier) Sign(ctx context.Context, payload []byte) ([]byte, []byte, error) {
-	sig, err := g.SignMessage(bytes.NewReader(payload), options.WithContext(ctx))
-	return sig, nil, err
 }
 
 // SignMessage signs the provided message using GCP KMS. If the message is provided,
@@ -168,6 +162,8 @@ func (c cryptoSignerWrapper) Sign(_ io.Reader, digest []byte, opts crypto.Signer
 	return c.sv.SignMessage(nil, gcpOptions...)
 }
 
+// CryptoSigner returns a crypto.Signer object that uses the underlying SignerVerifier, along with a crypto.SignerOpts object
+// that allows the KMS to be used in APIs that only accept the standard golang objects
 func (g *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) (crypto.Signer, crypto.SignerOpts, error) {
 	defaultHf, err := g.client.getHashFunc()
 	if err != nil {
@@ -184,6 +180,7 @@ func (g *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) 
 	return csw, defaultHf, nil
 }
 
+// SupportedAlgorithms returns the list of algorithms supported by the GCP KMS service
 func (g *SignerVerifier) SupportedAlgorithms() (result []string) {
 	for k := range algorithmMap {
 		result = append(result, k)
@@ -191,6 +188,7 @@ func (g *SignerVerifier) SupportedAlgorithms() (result []string) {
 	return
 }
 
+// DefaultAlgorithm returns the default algorithm for the GCP KMS service
 func (g *SignerVerifier) DefaultAlgorithm() string {
 	return Algorithm_ECDSA_P256_SHA256
 }

--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -51,11 +51,13 @@ const (
 	vaultV1DataPrefix = "vault:v1:"
 
 	// use a consistent key for cache lookups
-	CacheKey = "signer"
+	cacheKey = "signer"
 
+	// ReferenceScheme schemes for various KMS services are copied from https://github.com/google/go-cloud/tree/master/secrets
 	ReferenceScheme = "hashivault://"
 )
 
+// ValidReference returns a non-nil error if the reference string is invalid
 func ValidReference(ref string) error {
 	if !referenceRegex.MatchString(ref) {
 		return errReference
@@ -173,7 +175,7 @@ func (h *hashivaultClient) fetchPublicKey(_ context.Context) (crypto.PublicKey, 
 }
 
 func (h *hashivaultClient) public() (crypto.PublicKey, error) {
-	return h.keyCache.Get(CacheKey)
+	return h.keyCache.Get(cacheKey)
 }
 
 func (h hashivaultClient) sign(digest []byte, alg crypto.Hash) ([]byte, error) {

--- a/pkg/signature/message.go
+++ b/pkg/signature/message.go
@@ -36,6 +36,12 @@ func isSupportedAlg(alg crypto.Hash, supportedAlgs []crypto.Hash) bool {
 	return false
 }
 
+// ComputeDigestForSigning calculates the digest value for the specified message using a hash function selected by the following process:
+//
+// - if a digest value is already specified in a SignOption and the length of the digest matches that of the selected hash function, the
+// digest value will be returned without any further computation
+// - if a hash function is given using WithCryptoSignerOpts(opts) as a SignOption, it will be used (if it is in the supported list)
+// - otherwise defaultHashFunc will be used (if it is in the supported list)
 func ComputeDigestForSigning(rawMessage io.Reader, defaultHashFunc crypto.Hash, supportedHashFuncs []crypto.Hash, opts ...SignOption) (digest []byte, hashedWith crypto.Hash, err error) {
 	var cryptoSignerOpts crypto.SignerOpts = defaultHashFunc
 	for _, opt := range opts {
@@ -56,6 +62,12 @@ func ComputeDigestForSigning(rawMessage io.Reader, defaultHashFunc crypto.Hash, 
 	return
 }
 
+// ComputeDigestForVerifying calculates the digest value for the specified message using a hash function selected by the following process:
+//
+// - if a digest value is already specified in a SignOption and the length of the digest matches that of the selected hash function, the
+// digest value will be returned without any further computation
+// - if a hash function is given using WithCryptoSignerOpts(opts) as a SignOption, it will be used (if it is in the supported list)
+// - otherwise defaultHashFunc will be used (if it is in the supported list)
 func ComputeDigestForVerifying(rawMessage io.Reader, defaultHashFunc crypto.Hash, supportedHashFuncs []crypto.Hash, opts ...VerifyOption) (digest []byte, hashedWith crypto.Hash, err error) {
 	var cryptoSignerOpts crypto.SignerOpts = defaultHashFunc
 	for _, opt := range opts {

--- a/pkg/signature/options/context.go
+++ b/pkg/signature/options/context.go
@@ -19,15 +19,18 @@ import (
 	"context"
 )
 
+// RequestContext implements the functional option pattern for including a context during RPC
 type RequestContext struct {
 	NoOpOptionImpl
 	ctx context.Context
 }
 
+// ApplyContext sets the specified context as the functional option
 func (r RequestContext) ApplyContext(ctx *context.Context) {
 	*ctx = r.ctx
 }
 
+// WithContext specifies that the given context should be used in RPC to external services
 func WithContext(ctx context.Context) RequestContext {
 	return RequestContext{ctx: ctx}
 }

--- a/pkg/signature/options/digest.go
+++ b/pkg/signature/options/digest.go
@@ -15,15 +15,18 @@
 
 package options
 
+// RequestDigest implements the functional option pattern for specifying a digest value
 type RequestDigest struct {
 	NoOpOptionImpl
 	digest []byte
 }
 
+// ApplyDigest sets the specified digest value as the functional option
 func (r RequestDigest) ApplyDigest(digest *[]byte) {
 	*digest = r.digest
 }
 
+// WithDigest specifies that the given digest can be used by underlying signature implementations
 func WithDigest(digest []byte) RequestDigest {
 	return RequestDigest{digest: digest}
 }

--- a/pkg/signature/options/noop.go
+++ b/pkg/signature/options/noop.go
@@ -24,8 +24,17 @@ import (
 // NoOpOptionImpl implements the RPCOption, SignOption, VerifyOption interfaces as no-ops.
 type NoOpOptionImpl struct{}
 
-func (NoOpOptionImpl) ApplyContext(ctx *context.Context)                {}
-func (NoOpOptionImpl) ApplyCryptoSignerOpts(opts *crypto.SignerOpts)    {}
-func (NoOpOptionImpl) ApplyDigest(digest *[]byte)                       {}
-func (NoOpOptionImpl) ApplyRand(rand *io.Reader)                        {}
+// ApplyContext is a no-op required to fully implement the requisite interfaces
+func (NoOpOptionImpl) ApplyContext(ctx *context.Context) {}
+
+// ApplyCryptoSignerOpts is a no-op required to fully implement the requisite interfaces
+func (NoOpOptionImpl) ApplyCryptoSignerOpts(opts *crypto.SignerOpts) {}
+
+// ApplyDigest is a no-op required to fully implement the requisite interfaces
+func (NoOpOptionImpl) ApplyDigest(digest *[]byte) {}
+
+// ApplyRand is a no-op required to fully implement the requisite interfaces
+func (NoOpOptionImpl) ApplyRand(rand *io.Reader) {}
+
+// ApplyRemoteVerification is a no-op required to fully implement the requisite interfaces
 func (NoOpOptionImpl) ApplyRemoteVerification(remoteVerification *bool) {}

--- a/pkg/signature/options/rand.go
+++ b/pkg/signature/options/rand.go
@@ -20,15 +20,18 @@ import (
 	"io"
 )
 
+// RequestRand implements the functional option pattern for using a specific source of entropy
 type RequestRand struct {
 	NoOpOptionImpl
 	rand io.Reader
 }
 
+// ApplyRand sets the specified source of entropy as the functional option
 func (r RequestRand) ApplyRand(rand *io.Reader) {
 	*rand = r.rand
 }
 
+// WithRand specifies that the given source of entropy should be used in signing operations
 func WithRand(rand io.Reader) RequestRand {
 	r := rand
 	if r == nil {

--- a/pkg/signature/options/remoteverification.go
+++ b/pkg/signature/options/remoteverification.go
@@ -15,15 +15,18 @@
 
 package options
 
+// RequestRemoteVerification implements the functional option pattern for remotely verifiying signatures when possible
 type RequestRemoteVerification struct {
 	NoOpOptionImpl
 	remoteVerification bool
 }
 
+// ApplyRemoteVerification sets remote verification as a functional option
 func (r RequestRemoteVerification) ApplyRemoteVerification(remoteVerification *bool) {
 	*remoteVerification = r.remoteVerification
 }
 
+// WithRemoteVerification specifies that the verification operation should be performed remotely (vs in the process of the caller)
 func WithRemoteVerification(remoteVerification bool) RequestRemoteVerification {
 	return RequestRemoteVerification{remoteVerification: remoteVerification}
 }

--- a/pkg/signature/options/signeropts.go
+++ b/pkg/signature/options/signeropts.go
@@ -19,15 +19,18 @@ import (
 	"crypto"
 )
 
+// RequestCryptoSignerOpts implements the functional option pattern for supplying crypto.SignerOpts when signing or verifying
 type RequestCryptoSignerOpts struct {
 	NoOpOptionImpl
 	opts crypto.SignerOpts
 }
 
+// ApplyCryptoSignerOpts sets crypto.SignerOpts as a functional option
 func (r RequestCryptoSignerOpts) ApplyCryptoSignerOpts(opts *crypto.SignerOpts) {
 	*opts = r.opts
 }
 
+// WithCryptoSignerOpts specifies that provided crypto.SignerOpts be used during signing and verification operations
 func WithCryptoSignerOpts(opts crypto.SignerOpts) RequestCryptoSignerOpts {
 	var optsToUse crypto.SignerOpts = crypto.SHA256
 	if opts != nil {

--- a/pkg/signature/payload/payload.go
+++ b/pkg/signature/payload/payload.go
@@ -25,32 +25,37 @@ import (
 // CosignSignatureType is the value of `critical.type` in a SimpleContainerImage payload.
 const CosignSignatureType = "cosign container image signature"
 
-// Simple describes the structure of a basic container image signature payload, as defined at:
-// https://github.com/containers/image/blob/master/docs/containers-signature.5.md#json-data-format
+// SimpleContainerImage describes the structure of a basic container image signature payload, as defined at:
+//  https://github.com/containers/image/blob/master/docs/containers-signature.5.md#json-data-format
 type SimpleContainerImage struct {
-	Critical Critical               `json:"critical"`
-	Optional map[string]interface{} `json:"optional"`
+	Critical Critical               `json:"critical"` // Critical data critical to correctly evaluating the validity of the signature
+	Optional map[string]interface{} `json:"optional"` // Optional optional metadata about the image
 }
 
+// Critical data critical to correctly evaluating the validity of a signature
 type Critical struct {
-	Identity Identity `json:"identity"`
-	Image    Image    `json:"image"`
-	Type     string   `json:"type"`
+	Identity Identity `json:"identity"` // Identity claimed identity of the image
+	Image    Image    `json:"image"`    // Image identifies the container that the signature applies to
+	Type     string   `json:"type"`     // Type must be 'atomic container signature'
 }
 
+// Identity is the claimed identity of the image
 type Identity struct {
-	DockerReference string `json:"docker-reference"`
+	DockerReference string `json:"docker-reference"` // DockerReference is a reference used to refer to or download the image
 }
 
+// Image identifies the container image that the signature applies to
 type Image struct {
-	DockerManifestDigest string `json:"docker-manifest-digest"`
+	DockerManifestDigest string `json:"docker-manifest-digest"` // DockerManifestDigest the manifest digest of the signed container image
 }
 
+// Cosign describes a container image signed using Cosign
 type Cosign struct {
 	Image       name.Digest
 	Annotations map[string]interface{}
 }
 
+// SimpleContainerImage returns information about a container image in the github.com/containers/image/signature format
 func (p Cosign) SimpleContainerImage() SimpleContainerImage {
 	return SimpleContainerImage{
 		Critical: Critical{
@@ -66,12 +71,14 @@ func (p Cosign) SimpleContainerImage() SimpleContainerImage {
 	}
 }
 
+// MarshalJSON marshals the container signature into a []byte of JSON data
 func (p Cosign) MarshalJSON() ([]byte, error) {
 	return json.Marshal(p.SimpleContainerImage())
 }
 
 var _ json.Marshaler = Cosign{}
 
+// UnmarshalJSON unmarshals []byte of JSON data into a container signature object
 func (p *Cosign) UnmarshalJSON(data []byte) error {
 	if string(data) == "null" {
 		// JSON "null" is a no-op by convention

--- a/pkg/signature/publickey.go
+++ b/pkg/signature/publickey.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 )
 
+// PublicKeyProvider returns a PublicKey associated with a digital signature
 type PublicKeyProvider interface {
 	PublicKey(opts ...PublicKeyOption) (crypto.PublicKey, error)
 }

--- a/pkg/signature/rsapkcs1v15.go
+++ b/pkg/signature/rsapkcs1v15.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
+// RSAPKCS1v15Signer is a signature.Signer that uses the RSA PKCS1v15 algorithm
 type RSAPKCS1v15Signer struct {
 	hashFunc crypto.Hash
 	priv     *rsa.PrivateKey
@@ -106,6 +107,7 @@ func (r RSAPKCS1v15Signer) Sign(rand io.Reader, digest []byte, opts crypto.Signe
 	return r.SignMessage(nil, rsaOpts...)
 }
 
+// RSAPKCS1v15Verifier is a signature.Verifier that uses the RSA PKCS1v15 algorithm
 type RSAPKCS1v15Verifier struct {
 	publicKey *rsa.PublicKey
 	hashFunc  crypto.Hash
@@ -168,6 +170,7 @@ func (r RSAPKCS1v15Verifier) VerifySignature(signature, message io.Reader, opts 
 	return rsa.VerifyPKCS1v15(r.publicKey, hf, digest, sigBytes)
 }
 
+// RSAPKCS1v15SignerVerifier is a signature.SignerVerifier that uses the RSA PKCS1v15 algorithm
 type RSAPKCS1v15SignerVerifier struct {
 	*RSAPKCS1v15Signer
 	*RSAPKCS1v15Verifier

--- a/pkg/signature/rsapss.go
+++ b/pkg/signature/rsapss.go
@@ -33,6 +33,7 @@ var rsaSupportedHashFuncs = []crypto.Hash{
 	crypto.SHA1,
 }
 
+// RSAPSSSigner is a signature.Signer that uses the RSA PSS algorithm
 type RSAPSSSigner struct {
 	hashFunc crypto.Hash
 	priv     *rsa.PrivateKey
@@ -125,6 +126,7 @@ func (r RSAPSSSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts
 	return r.SignMessage(nil, rsaOpts...)
 }
 
+// RSAPSSVerifier is a signature.Verifier that uses the RSA PSS algorithm
 type RSAPSSVerifier struct {
 	publicKey *rsa.PublicKey
 	hashFunc  crypto.Hash
@@ -196,6 +198,7 @@ func (r RSAPSSVerifier) VerifySignature(signature, message io.Reader, opts ...Ve
 	return rsa.VerifyPSS(r.publicKey, hf, digest, sigBytes, pssOpts)
 }
 
+// RSAPSSSignerVerifier is a signature.SignerVerifier that uses the RSA PSS algorithm
 type RSAPSSSignerVerifier struct {
 	*RSAPSSSigner
 	*RSAPSSVerifier

--- a/pkg/signature/signer.go
+++ b/pkg/signature/signer.go
@@ -35,6 +35,7 @@ import (
 	_ "golang.org/x/crypto/sha3"
 )
 
+// Signer creates digital signatures over a message using a specified key pair
 type Signer interface {
 	PublicKeyProvider
 	SignMessage(message io.Reader, opts ...SignOption) ([]byte, error)

--- a/pkg/signature/signerverifier.go
+++ b/pkg/signature/signerverifier.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
+// SignerVerifier creates and verifies digital signatures over a message using a specified key pair
 type SignerVerifier interface {
 	Signer
 	Verifier

--- a/pkg/signature/util.go
+++ b/pkg/signature/util.go
@@ -25,6 +25,7 @@ import (
 	sigpayload "github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
+// SignImage signs a container manifest using the specified signer object
 func SignImage(signer SignerVerifier, image name.Digest, optionalAnnotations map[string]interface{}) (payload, signature []byte, err error) {
 	imgPayload := sigpayload.Cosign{
 		Image:       image,
@@ -41,6 +42,7 @@ func SignImage(signer SignerVerifier, image name.Digest, optionalAnnotations map
 	return payload, signature, nil
 }
 
+// VerifyImageSignature verifies a signature over a container manifest
 func VerifyImageSignature(signer SignerVerifier, payload, signature []byte) (image name.Digest, annotations map[string]interface{}, err error) {
 	if err := signer.VerifySignature(bytes.NewReader(signature), bytes.NewReader(payload)); err != nil {
 		return name.Digest{}, nil, fmt.Errorf("signature verification failed: %v", err)

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
+// Verifier verifies the digital signature using a specified public key
 type Verifier interface {
 	PublicKeyProvider
 	VerifySignature(signature, message io.Reader, opts ...VerifyOption) error

--- a/test/e2e/kms/vault_test.go
+++ b/test/e2e/kms/vault_test.go
@@ -79,11 +79,6 @@ func (suite *VaultSuite) TearDownSuite() {
 	require.Nil(suite.T(), err)
 }
 
-func (suite *VaultSuite) TestProviders() {
-	providers := kms.ProvidersMux().Providers()
-	assert.Len(suite.T(), providers, 4)
-}
-
 func (suite *VaultSuite) TestProvider() {
 	suite.GetProvider("provider")
 }


### PR DESCRIPTION
Adds documentation to various methods throughout library to remove lint
errors.

The only (minor) functional changes are in KMS, where certain methods and variables
were made private where it seemed appropriate and unused methods were removed.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #154

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
