### PR TITLE
Upgraded go-securesystemslib from 0.1.0 to 0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/secure-systems-lab/go-securesystemslib v0.1.0
+	github.com/secure-systems-lab/go-securesystemslib v0.2.0
 	github.com/segmentio/ksuid v1.0.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -809,6 +809,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/secure-systems-lab/go-securesystemslib v0.1.0 h1:wZNQ7t1UTOQtDL/+PBPzxI52gLQGyC7qfXyJh6Lgf1Y=
 github.com/secure-systems-lab/go-securesystemslib v0.1.0/go.mod h1:eIjBmIP8LD2MLBL/DkQWayLiz006Q4p+hCu79rvWleY=
+github.com/secure-systems-lab/go-securesystemslib v0.2.0 h1:9beLHgmhA2KEqJkFh1bs/YlnHkazv26GCXqfcUdC1YI=
+github.com/secure-systems-lab/go-securesystemslib v0.2.0/go.mod h1:eIjBmIP8LD2MLBL/DkQWayLiz006Q4p+hCu79rvWleY=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/signature/dsse/dsse.go
+++ b/pkg/signature/dsse/dsse.go
@@ -51,7 +51,7 @@ func (w *wrappedSigner) SignMessage(r io.Reader, opts ...signature.SignOption) (
 	if err != nil {
 		return nil, err
 	}
-	pae := dsse.PAE(w.payloadType, string(p))
+	pae := dsse.PAE(w.payloadType, p)
 	sig, err := w.s.SignMessage(bytes.NewReader(pae), opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Upgraded go-securesystemslib from 0.1.0 to 0.2.0

Fixes this https://github.com/sigstore/sigstore/pull/175 

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
