### PR TITLE
bump github.com/secure-systems-lab/go-securesystemslib to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/secure-systems-lab/go-securesystemslib v0.2.0
+	github.com/secure-systems-lab/go-securesystemslib v0.3.0
 	github.com/segmentio/ksuid v1.0.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -813,6 +813,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/secure-systems-lab/go-securesystemslib v0.2.0 h1:9beLHgmhA2KEqJkFh1bs/YlnHkazv26GCXqfcUdC1YI=
 github.com/secure-systems-lab/go-securesystemslib v0.2.0/go.mod h1:eIjBmIP8LD2MLBL/DkQWayLiz006Q4p+hCu79rvWleY=
+github.com/secure-systems-lab/go-securesystemslib v0.3.0 h1:PH0mUKuUSXVEVDbrKMgGPcrqrnKA8gJii614+EKKi7g=
+github.com/secure-systems-lab/go-securesystemslib v0.3.0/go.mod h1:o8hhjkbNl2gOamKUA/eNW3xUrntHT9L4W89W1nfj43U=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
 github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/pkg/signature/dsse/dsse.go
+++ b/pkg/signature/dsse/dsse.go
@@ -97,18 +97,43 @@ func (w *wrappedVerifier) VerifySignature(s io.Reader, _ io.Reader, opts ...sign
 		return nil
 	}
 
-	verifier := dsse.NewEnvelopeVerifier(&VerifierAdapter{SignatureVerifier: w.v})
-	return verifier.Verify(&env)
+	pub, err := w.PublicKey()
+	if err != nil {
+		return err
+	}
+	verifier, err := dsse.NewEnvelopeVerifier(&VerifierAdapter{
+		SignatureVerifier: w.v,
+
+		Pub:   pub,
+		KeyId: "", // We do not want to limit verification to a specific key.
+	})
+	if err != nil {
+		return err
+	}
+	_, err = verifier.Verify(&env)
+	return err
 }
 
 // VerifierAdapter wraps a `sigstore/signature.Verifier`, making it compatible with `go-securesystemslib/dsse.Verifier`.
 type VerifierAdapter struct {
 	SignatureVerifier signature.Verifier
+	Pub               crypto.PublicKey
+	KeyId             string
 }
 
 // Verify implements `go-securesystemslib/dsse.Verifier`
-func (a *VerifierAdapter) Verify(_ string, data []byte, sig []byte) error {
+func (a *VerifierAdapter) Verify(data []byte, sig []byte) error {
 	return a.SignatureVerifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data))
+}
+
+// Public implements `go-securesystemslib/dsse.Verifier`
+func (a *VerifierAdapter) Public() crypto.PublicKey {
+	return a.Pub
+}
+
+// KeyID implements `go-securesystemslib/dsse.Verifier`
+func (a *VerifierAdapter) KeyID() (string, error) {
+	return a.KeyId, nil
 }
 
 // WrapSignerVerifier returns a signature.SignerVerifier that uses the DSSE encoding format

--- a/pkg/signature/dsse/dsse.go
+++ b/pkg/signature/dsse/dsse.go
@@ -104,8 +104,8 @@ func (w *wrappedVerifier) VerifySignature(s io.Reader, _ io.Reader, opts ...sign
 	verifier, err := dsse.NewEnvelopeVerifier(&VerifierAdapter{
 		SignatureVerifier: w.v,
 
-		Pub:   pub,
-		KeyId: "", // We do not want to limit verification to a specific key.
+		Pub:      pub,
+		PubKeyID: "", // We do not want to limit verification to a specific key.
 	})
 	if err != nil {
 		return err
@@ -118,7 +118,7 @@ func (w *wrappedVerifier) VerifySignature(s io.Reader, _ io.Reader, opts ...sign
 type VerifierAdapter struct {
 	SignatureVerifier signature.Verifier
 	Pub               crypto.PublicKey
-	KeyId             string
+	PubKeyID          string
 }
 
 // Verify implements `go-securesystemslib/dsse.Verifier`
@@ -133,7 +133,7 @@ func (a *VerifierAdapter) Public() crypto.PublicKey {
 
 // KeyID implements `go-securesystemslib/dsse.Verifier`
 func (a *VerifierAdapter) KeyID() (string, error) {
-	return a.KeyId, nil
+	return a.PubKeyID, nil
 }
 
 // WrapSignerVerifier returns a signature.SignerVerifier that uses the DSSE encoding format


### PR DESCRIPTION
Obsoletes https://github.com/sigstore/sigstore/pull/186

```release-note
NONE
```
