### PR TITLE
fix wrong return value in error case

### DIFF
--- a/pkg/signature/dsse/dsse.go
+++ b/pkg/signature/dsse/dsse.go
@@ -94,7 +94,7 @@ func (w *wrappedVerifier) VerifySignature(s io.Reader, _ io.Reader, opts ...sign
 
 	env := dsse.Envelope{}
 	if err := json.Unmarshal(sig, &env); err != nil {
-		return nil
+		return err
 	}
 
 	pub, err := w.PublicKey()

--- a/pkg/signature/dsse/dsse_test.go
+++ b/pkg/signature/dsse/dsse_test.go
@@ -72,3 +72,22 @@ func TestRoundTrip(t *testing.T) {
 		t.Errorf("Expected payload %s, got %s", data, env.Payload)
 	}
 }
+
+func TestInvalidSignature(t *testing.T) {
+	p, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := signature.LoadECDSAVerifier(&p.PublicKey, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wv := WrapVerifier(v)
+	sig := []byte("not valid JSON")
+
+	if err := wv.VerifySignature(bytes.NewReader(sig), nil); err == nil {
+		t.Fatalf("Did not fail verification on bogus signature")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #191 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
