### PR TITLE
Dsse multi signature wrapper

### DIFF
--- a/pkg/signature/dsse/adapters.go
+++ b/pkg/signature/dsse/adapters.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dsse
 
 import (

--- a/pkg/signature/dsse/adapters.go
+++ b/pkg/signature/dsse/adapters.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-// VerifierAdapter wraps a `sigstore/signature.Verifier`, making it compatible with `go-securesystemslib/dsse.Verifier`.
+// SignerAdapter wraps a `sigstore/signature.Signer`, making it compatible with `go-securesystemslib/dsse.Signer`.
 type SignerAdapter struct {
 	SignatureSigner signature.Signer
 	Pub             crypto.PublicKey

--- a/pkg/signature/dsse/adapters.go
+++ b/pkg/signature/dsse/adapters.go
@@ -1,0 +1,59 @@
+package dsse
+
+import (
+	"bytes"
+	"crypto"
+	"errors"
+
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+// VerifierAdapter wraps a `sigstore/signature.Verifier`, making it compatible with `go-securesystemslib/dsse.Verifier`.
+type SignerAdapter struct {
+	SignatureSigner signature.Signer
+	Pub             crypto.PublicKey
+	Opts            []signature.SignOption
+	PubKeyID        string
+}
+
+// Sign implements `go-securesystemslib/dsse.Signer`
+func (a *SignerAdapter) Sign(data []byte) ([]byte, error) {
+	return a.SignatureSigner.SignMessage(bytes.NewReader(data), a.Opts...)
+}
+
+// Verify disabled `go-securesystemslib/dsse.Verifier`
+func (a *SignerAdapter) Verify(data []byte, sig []byte) error {
+	return errors.New("Verify disabled")
+}
+
+// Public implements `go-securesystemslib/dsse.Verifier`
+func (a *SignerAdapter) Public() crypto.PublicKey {
+	return a.Pub
+}
+
+// KeyID implements `go-securesystemslib/dsse.Verifier`
+func (a SignerAdapter) KeyID() (string, error) {
+	return a.PubKeyID, nil
+}
+
+// VerifierAdapter wraps a `sigstore/signature.Verifier`, making it compatible with `go-securesystemslib/dsse.Verifier`.
+type VerifierAdapter struct {
+	SignatureVerifier signature.Verifier
+	Pub               crypto.PublicKey
+	PubKeyID          string
+}
+
+// Verify implements `go-securesystemslib/dsse.Verifier`
+func (a *VerifierAdapter) Verify(data []byte, sig []byte) error {
+	return a.SignatureVerifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data))
+}
+
+// Public implements `go-securesystemslib/dsse.Verifier`
+func (a *VerifierAdapter) Public() crypto.PublicKey {
+	return a.Pub
+}
+
+// KeyID implements `go-securesystemslib/dsse.Verifier`
+func (a *VerifierAdapter) KeyID() (string, error) {
+	return a.PubKeyID, nil
+}

--- a/pkg/signature/dsse/dsse.go
+++ b/pkg/signature/dsse/dsse.go
@@ -114,28 +114,6 @@ func (w *wrappedVerifier) VerifySignature(s io.Reader, _ io.Reader, opts ...sign
 	return err
 }
 
-// VerifierAdapter wraps a `sigstore/signature.Verifier`, making it compatible with `go-securesystemslib/dsse.Verifier`.
-type VerifierAdapter struct {
-	SignatureVerifier signature.Verifier
-	Pub               crypto.PublicKey
-	PubKeyID          string
-}
-
-// Verify implements `go-securesystemslib/dsse.Verifier`
-func (a *VerifierAdapter) Verify(data []byte, sig []byte) error {
-	return a.SignatureVerifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data))
-}
-
-// Public implements `go-securesystemslib/dsse.Verifier`
-func (a *VerifierAdapter) Public() crypto.PublicKey {
-	return a.Pub
-}
-
-// KeyID implements `go-securesystemslib/dsse.Verifier`
-func (a *VerifierAdapter) KeyID() (string, error) {
-	return a.PubKeyID, nil
-}
-
 // WrapSignerVerifier returns a signature.SignerVerifier that uses the DSSE encoding format
 func WrapSignerVerifier(sv signature.SignerVerifier, payloadType string) signature.SignerVerifier {
 	signer := &wrappedSigner{

--- a/pkg/signature/dsse/dsse_test.go
+++ b/pkg/signature/dsse/dsse_test.go
@@ -73,6 +73,98 @@ func TestRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMultiRoundTrip(t *testing.T) {
+	p, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sv, err := signature.LoadECDSASignerVerifier(p, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sv2, err := signature.LoadECDSASignerVerifier(p2, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := "sometestdata"
+	payloadType := "foo"
+
+	wsv := WrapMultiSignerVerifier(payloadType, 2, sv, sv2)
+
+	sig, err := wsv.SignMessage(strings.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := wsv.VerifySignature(bytes.NewReader(sig), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	env := dsse.Envelope{}
+	if err := json.Unmarshal(sig, &env); err != nil {
+		t.Fatal(err)
+	}
+	if env.PayloadType != payloadType {
+		t.Errorf("Expected payloadType %s, got %s", payloadType, env.PayloadType)
+	}
+
+	got, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != data {
+		t.Errorf("Expected payload %s, got %s", data, env.Payload)
+	}
+}
+
+func TestInvalidThresholdMultiRoundTrip(t *testing.T) {
+	p, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sv, err := signature.LoadECDSASignerVerifier(p, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	p2, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sv2, err := signature.LoadECDSASignerVerifier(p2, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := "sometestdata"
+	payloadType := "foo"
+
+	ws := WrapMultiSigner(payloadType, sv, sv2)
+
+	sig, err := ws.SignMessage(strings.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wv := WrapMultiVerifier(payloadType, 2, sv)
+
+	if err := wv.VerifySignature(bytes.NewReader(sig), nil); err == nil {
+		t.Fatalf("Did not fail verification on bogus signature")
+	}
+
+}
+
 func TestInvalidSignature(t *testing.T) {
 	p, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/pkg/signature/dsse/multidsse.go
+++ b/pkg/signature/dsse/multidsse.go
@@ -150,6 +150,7 @@ func (wL *wrappedMultiVerifier) VerifySignature(s io.Reader, _ io.Reader, opts .
 	return err
 }
 
+// WrapMultiSignerVerifier returns a signature.SignerVerifier that uses the DSSE encoding format
 func WrapMultiSignerVerifier(payloadType string, threshold int, svL ...signature.SignerVerifier) signature.SignerVerifier {
 
 	var signerL []signature.Signer

--- a/pkg/signature/dsse/multidsse.go
+++ b/pkg/signature/dsse/multidsse.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package dsse
 
 import (

--- a/pkg/signature/dsse/multidsse.go
+++ b/pkg/signature/dsse/multidsse.go
@@ -28,7 +28,6 @@ import (
 
 type wrappedMultiSigner struct {
 	sLAdapters  []dsse.SignVerifier
-	threshold   int
 	payloadType string
 }
 

--- a/pkg/signature/dsse/multidsse.go
+++ b/pkg/signature/dsse/multidsse.go
@@ -1,0 +1,175 @@
+package dsse
+
+import (
+	"crypto"
+	"encoding/json"
+	"errors"
+	"io"
+	"io/ioutil"
+
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+type wrappedMultiSigner struct {
+	sLAdapters  []dsse.SignVerifier
+	threshold   int
+	payloadType string
+}
+
+// WrapMultiSigner returns a signature.Signer that uses the DSSE encoding format
+func WrapMultiSigner(payloadType string, sL ...signature.Signer) signature.Signer {
+	var signerAdapterL []dsse.SignVerifier
+	for _, s := range sL {
+		pub, err := s.PublicKey()
+		if err != nil {
+			return nil
+		}
+
+		keyID, err := dsse.SHA256KeyID(pub)
+		if err != nil {
+			keyID = ""
+		}
+
+		signerAdapter := &SignerAdapter{
+			SignatureSigner: s,
+			Pub:             s.PublicKey,
+			PubKeyID:        keyID, // We do not want to limit verification to a specific key.
+		}
+
+		signerAdapterL = append(signerAdapterL, signerAdapter)
+
+	}
+
+	return &wrappedMultiSigner{
+		sLAdapters:  signerAdapterL,
+		payloadType: payloadType,
+	}
+}
+
+// PublicKey returns the public key associated with the signer
+func (wL *wrappedMultiSigner) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return nil, errors.New("Not supported for multi signatures")
+}
+
+// SignMessage signs the provided stream in the reader using the DSSE encoding format
+func (wL *wrappedMultiSigner) SignMessage(r io.Reader, opts ...signature.SignOption) ([]byte, error) {
+	p, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Threshold does not matter signer is not used for verification.
+	envSigner, err := dsse.NewMultiEnvelopeSigner(1, wL.sLAdapters...)
+	if err != nil {
+		return nil, err
+	}
+
+	env, err := envSigner.SignPayload(wL.payloadType, p)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(env)
+}
+
+type wrappedMultiVerifier struct {
+	vLAdapters  []dsse.Verifier
+	threshold   int
+	payloadType string
+}
+
+// WrapMultiVerifier returns a signature.Verifier that uses the DSSE encoding format
+func WrapMultiVerifier(payloadType string, threshold int, vL ...signature.Verifier) signature.Verifier {
+	var verifierAdapterL []dsse.Verifier
+	for _, v := range vL {
+		pub, err := v.PublicKey()
+		if err != nil {
+			return nil
+		}
+
+		keyID, err := dsse.SHA256KeyID(pub)
+		if err != nil {
+			keyID = ""
+		}
+
+		verifierAdapter := &VerifierAdapter{
+			SignatureVerifier: v,
+			Pub:               v.PublicKey,
+			PubKeyID:          keyID, // We do not want to limit verification to a specific key.
+		}
+
+		verifierAdapterL = append(verifierAdapterL, verifierAdapter)
+
+	}
+
+	return &wrappedMultiVerifier{
+		vLAdapters:  verifierAdapterL,
+		payloadType: payloadType,
+		threshold:   threshold,
+	}
+}
+
+// PublicKey returns the public key associated with the signer
+func (wL *wrappedMultiVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return nil, errors.New("Not supported for multi signatures")
+}
+
+// VerifySignature verifies the signature specified in an DSSE envelope
+func (wL *wrappedMultiVerifier) VerifySignature(s io.Reader, _ io.Reader, opts ...signature.VerifyOption) error {
+	sig, err := ioutil.ReadAll(s)
+	if err != nil {
+		return err
+	}
+
+	env := dsse.Envelope{}
+	if err := json.Unmarshal(sig, &env); err != nil {
+		return err
+	}
+
+	envVerifier, err := dsse.NewMultiEnvelopeVerifier(wL.threshold, wL.vLAdapters...)
+	if err != nil {
+		return err
+	}
+
+	_, err = envVerifier.Verify(&env)
+	return err
+}
+
+func WrapMultiSignerVerifier(payloadType string, threshold int, svL ...signature.SignerVerifier) signature.SignerVerifier {
+
+	var signerL []signature.Signer
+	var verifierL []signature.Verifier
+	for _, sv := range svL {
+		signerL = append(signerL, sv)
+		verifierL = append(verifierL, sv)
+	}
+
+	sL := WrapMultiSigner(payloadType, signerL...)
+	vL := WrapMultiVerifier(payloadType, threshold, verifierL...)
+
+	return &wrappedMultiSignerVerifier{
+		signer:   sL,
+		verifier: vL,
+	}
+}
+
+type wrappedMultiSignerVerifier struct {
+	signer   signature.Signer
+	verifier signature.Verifier
+}
+
+// PublicKey returns the public key associated with the verifier
+func (w *wrappedMultiSignerVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return w.signer.PublicKey(opts...)
+}
+
+// VerifySignature verifies the signature specified in an DSSE envelope
+func (w *wrappedMultiSignerVerifier) VerifySignature(s io.Reader, r io.Reader, opts ...signature.VerifyOption) error {
+	return w.verifier.VerifySignature(s, r, opts...)
+}
+
+// SignMessage signs the provided stream in the reader using the DSSE encoding format
+func (w *wrappedMultiSignerVerifier) SignMessage(r io.Reader, opts ...signature.SignOption) ([]byte, error) {
+	return w.signer.SignMessage(r, opts...)
+}


### PR DESCRIPTION
We have added multi sign support in the DSSE v0.3.0 library,
PR suggests a wrapper to access these signer/verifiers.

Signed-off-by: houdini91 <mdstrauss91@gmail.com>
@adityasaky