### PR TITLE
pin actions by digest; update chrome install to use signed repo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,15 +32,16 @@ jobs:
         language: [ 'go' ]
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@300c8b6dcbaf905eb250b06113e2e62c340a2d20 #v1.0.27
       with:
         languages: ${{ matrix.language }}
+
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@300c8b6dcbaf905eb250b06113e2e62c340a2d20 #v1.0.27
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@300c8b6dcbaf905eb250b06113e2e62c340a2d20 #v1.0.27

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -29,26 +29,26 @@ jobs:
     name: e2e integration tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
       with:
         go-version: ${{ env.GO_VERSION }}
 
     - name: Cache Modules
-      uses: actions/cache@v2
+      uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed #v2.1.7
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Pull chrome
-      run: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-
-    - name: Install chrome
-      run: sudo apt install ./google-chrome-stable_current_amd64.deb
+    - name: Pull chrome (from ubuntu repository)
+      run: |
+        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+        sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+        sudo apt update && sudo apt install -y google-chrome-stable
 
     - name: Docker Build
       working-directory: ./test/e2e

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -20,7 +20,7 @@ jobs:
           fuzz-seconds: 600
           dry-run: false
       - name: Upload Crash
-        uses: actions/upload-artifact@v2.3.1
+        uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 #v2.3.1
         if: failure() && steps.build.outcome == 'success'
         with:
           name: artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,14 @@ jobs:
     name: unit tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
+    - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: Cache Modules
-      uses: actions/cache@v2
+      uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed #v2.1.7
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,12 +26,12 @@ jobs:
     name: license boilerplate check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
+      - uses: actions/setup-go@424fc82d43fa5a37540bae62709ddcc23d9520d4 #v2.1.5
         with:
           go-version: '1.16'
       - name: Install addlicense
-        run: go install github.com/google/addlicense@latest
+        run: go install github.com/google/addlicense@v1.0.0
       - name: Check license headers
         run: |
           set -e
@@ -42,9 +42,9 @@ jobs:
     name: lint checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.4.0
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 #v2.5.2
         timeout-minutes: 5
         with:
           version: latest


### PR DESCRIPTION
Addressing https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

data from running: `scorecard --show-details --repo=https://github.com/sigstore/sigstore/ --checks Pinned-Dependencies --format json`:

```
{
  "date": "2022-01-12",
  "repo": {
    "name": "github.com/sigstore/sigstore",
    "commit": "4133450ec3d7ca2d997251fe80b4bbbaeb790910"
  },
  "scorecard": {
    "version": "61a0124",
    "commit": "61a01244078b61abf5a2cdced8961927661edb8c"
  },
  "score": 6,
  "checks": [
    {
      "details": [
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql.yml:35",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql.yml:39",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql.yml:43",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/codeql.yml:46",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/e2e_test.yml:32",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/e2e_test.yml:35",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/e2e_test.yml:40",
        "Warn: third-party action not pinned by hash: .github/workflows/fuzzing.yml:12",
        "Warn: third-party action not pinned by hash: .github/workflows/fuzzing.yml:17",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/fuzzing.yml:23",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/test.yml:35",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/test.yml:38",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/test.yml:42",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:45",
        "Warn: third-party action not pinned by hash: .github/workflows/verify.yml:47",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:29",
        "Warn: GitHub-owned action not pinned by hash: .github/workflows/verify.yml:30",
        "Info: Dockerfile dependencies are pinned",
        "Info: no insecure (not pinned by hash) dependency downloads found in Dockerfiles",
        "Info: no insecure (not pinned by hash) dependency downloads found in shell scripts",
        "Warn: go installation not pinned by hash: .github/workflows/verify.yml:35"
      ],
      "score": 6,
      "reason": "dependency not pinned by hash detected -- score normalized to 6",
      "name": "Pinned-Dependencies",
      "documentation": {
        "url": "https://github.com/ossf/scorecard/blob/61a01244078b61abf5a2cdced8961927661edb8c/docs/checks.md#pinned-dependencies",
        "short": "Determines if the project has declared and pinned its dependencies."
      }
    }
  ],
  "metadata": null
}

```

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
