### PR TITLE
KMS: Change how the Azure authentication method is handled

### DIFF
--- a/pkg/signature/kms/azure/README.md
+++ b/pkg/signature/kms/azure/README.md
@@ -1,14 +1,55 @@
 # Azure KMS
 
-In order to use Azure KMS with sigstore project you should setup the azure first, the key creation
-will be handled in sigstore, however the vault and any needed permission will not and those things need to be configured.
+In order to use Azure KMS ([Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/basic-concepts)) with the sigstore project you need to have a few things setup in Azure first.
+The key creation will be handled in sigstore, however the Azure Key Vault and the required permission will have to be configured before.
 
-### What I need?
+## Azure Prerequisites
 
-- Create a Resource Group
-- In this Resource Group create the Azure KMS
-- Configure any custom permission
+- [Resource Group](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal#what-is-a-resource-group)
+- [Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/general/basic-concepts)
+- [Key Vault permissions](https://docs.microsoft.com/en-us/azure/key-vault/general/rbac-guide)
+- [Container Registry](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-intro) _(not required, but used in below examples)_
 
-After that you can use the created vault to generate the key, sign and verify.
+## Permissions (Access Policies)
 
-For more information check the official Azure Docs: https://azure.microsoft.com/en-us/services/key-vault/
+Different commands require different Key Vault access policies. For more information check the official [Azure Docs](https://azure.microsoft.com/en-us/services/key-vault/).
+
+**cosign generate-key-pair**
+
+Required access policies (keys): `get`, `create`
+
+```shell
+cosign generate-key-pair --kms azurekms://[Key Vault Name].vault.azure.net/[Key Name]
+```
+
+**cosign sign**
+
+Required access policies (keys): `get`, `sign`
+
+```shell
+az acr login --name [Container Registry Name]
+cosign sign --key azurekms://[Key Vault Name].vault.azure.net/[Key Name] [Container Registry Name].azurecr.io/[Image Name]
+```
+
+**cosign verify**
+
+Required access policy (keys): `verify`
+
+```shell
+az acr login --name [Container Registry Name]
+cosign verify --key azurekms://[Key Vault Name].vault.azure.net/[Key Name] [Container Registry Name].azurecr.io/[Image Name]
+```
+
+## Authentication
+
+There are multiple authentication methods supported for Azure Key Vault and by default they will be evaluated in the following order:
+
+1. Client credentials (FromEnvironment)
+1. Client certificate (FromEnvironment)
+1. Username password (FromEnvironment)
+1. MSI (FromEnvironment)
+1. CLI (FromCLI)
+
+You can force either `FromEnvironment` or `FromCLI` by configuring the environment variable `AZURE_AUTH_METHOD` to either `environment` or `cli`.
+
+For backward compatibility, if you configure `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`, `FromEnvironment` will be used.

--- a/pkg/signature/kms/azure/client_test.go
+++ b/pkg/signature/kms/azure/client_test.go
@@ -1,0 +1,105 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetAuthenticationMethod(t *testing.T) {
+	clearEnv := map[string]string{
+		"AZURE_TENANT_ID":     "",
+		"AZURE_CLIENT_ID":     "",
+		"AZURE_CLIENT_SECRET": "",
+		"AZURE_AUTH_METHOD":   "",
+	}
+	resetEnv := testSetEnv(t, clearEnv)
+	defer resetEnv()
+
+	cases := []struct {
+		testDescription      string
+		environmentVariables map[string]string
+		expectedResult       authenticationMethod
+	}{
+		{
+			testDescription:      "No environment variables set",
+			environmentVariables: map[string]string{},
+			expectedResult:       unknownAuthenticationMethod,
+		},
+		{
+			testDescription: "AZURE_AUTH_METHOD=environment",
+			environmentVariables: map[string]string{
+				"AZURE_AUTH_METHOD": "environment",
+			},
+			expectedResult: environmentAuthenticationMethod,
+		},
+		{
+			testDescription: "AZURE_AUTH_METHOD=cli",
+			environmentVariables: map[string]string{
+				"AZURE_AUTH_METHOD": "cli",
+			},
+			expectedResult: cliAuthenticationMethod,
+		},
+		{
+			testDescription: "Set environment variables AZURE_TENANT_ID, AZURE_CLIENT_ID & AZURE_CLIENT_SECRET",
+			environmentVariables: map[string]string{
+				"AZURE_TENANT_ID":     "foo",
+				"AZURE_CLIENT_ID":     "bar",
+				"AZURE_CLIENT_SECRET": "baz",
+			},
+			expectedResult: environmentAuthenticationMethod,
+		},
+	}
+
+	for i, c := range cases {
+		t.Logf("Test #%d: %s", i, c.testDescription)
+		reset := testSetEnv(t, c.environmentVariables)
+
+		result := getAuthenticationMethod()
+		if result != c.expectedResult {
+			t.Logf("got: %q, want: %q", result, c.expectedResult)
+			t.Fail()
+		}
+
+		reset()
+	}
+}
+
+func testSetEnv(t *testing.T, s map[string]string) func() {
+	t.Helper()
+
+	backup := map[string]string{}
+	for k, v := range s {
+		currentEnv := os.Getenv(k)
+		backup[k] = currentEnv
+		if v == "" {
+			os.Unsetenv(k)
+			continue
+		}
+		os.Setenv(k, v)
+	}
+
+	return func() {
+		for k, v := range backup {
+			if v == "" {
+				os.Unsetenv(k)
+				continue
+			}
+			os.Setenv(k, v)
+		}
+	}
+}


### PR DESCRIPTION
#### Summary
This patch removes the requirement of having the environment variables `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET` set to use the Azure KMS (KeyVault).

By removing the requirement, we enable usage of MSI (Managed Service Identity) through the `NewAuthorizerFromEnvironment()` and we at the same time add support for the `NewAuthorizerFromCLI()`.

By splitting the function of calculating what method to use to it's own function , `getAuthenticationMethod()`, it's possible to test the logic separately.

We also introduce the new environment variable `AZURE_AUTH_METHOD` which if set to `environment` will use `FromEnvironment()` (may be useful for the MSI case) and if set to `cli` will use `FromCLI()`.

If nothing is defined, `FromEnvironment()` will be tested first and then `FromCLI()`. :^)

#### Ticket Link
Fixes #223 

#### Release Note
```release-note
Add support for more Azure KMS authentication methods.
```
