### PR TITLE
Fix: verify with HashiVault KMS

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -1,4 +1,3 @@
-
 //
 // Copyright 2021 The Sigstore Authors.
 //

--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -1,3 +1,4 @@
+
 //
 // Copyright 2021 The Sigstore Authors.
 //
@@ -209,6 +210,7 @@ func (h hashivaultClient) verify(sig, digest []byte, alg crypto.Hash) error {
 
 	result, err := client.Write(fmt.Sprintf("/%s/verify/%s/%s", h.transitSecretEnginePath, h.keyPath, hashString(alg)), map[string]interface{}{
 		"input":     base64.StdEncoding.EncodeToString(digest),
+		"prehashed": alg != crypto.Hash(0),
 		"signature": fmt.Sprintf("%s%s", vaultDataPrefix, encodedSig),
 	})
 
@@ -221,9 +223,15 @@ func (h hashivaultClient) verify(sig, digest []byte, alg crypto.Hash) error {
 		return errors.New("corrupted response")
 	}
 
-	if isValid, ok := valid.(bool); ok && isValid {
+	isValid, ok := valid.(bool)
+	if !ok {
+		return fmt.Errorf("data type assertion for field `valid` failed: %T %#v", valid.(bool), valid.(bool))
+	}
+
+	if !isValid {
 		return errors.New("Failed vault verification")
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This patch fixes issue with verification command when used with HashiVault KMS.

For `verify` command: see details in: https://github.com/sigstore/cosign/issues/1301

For `verify-blob` command:

```shell
cosign verify-blob --key=hashivault://my-key --signature=file.sig <path-to-arbitrary-file>
Verified OK
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
https://github.com/sigstore/cosign/issues/1301

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fix verification with HashiVault KMS
```
