### PR TITLE
Drop SHA1, SHA224 for RSA-PSS/PKCS#1, enforce for RSA-PKCS#1

### DIFF
--- a/pkg/signature/rsapkcs1v15.go
+++ b/pkg/signature/rsapkcs1v15.go
@@ -33,13 +33,13 @@ type RSAPKCS1v15Signer struct {
 
 // LoadRSAPKCS1v15Signer calculates signatures using the specified private key and hash algorithm.
 //
-// hf must not be crypto.Hash(0).
+// hf must be either SHA256, SHA388, or SHA512.
 func LoadRSAPKCS1v15Signer(priv *rsa.PrivateKey, hf crypto.Hash) (*RSAPKCS1v15Signer, error) {
 	if priv == nil {
 		return nil, errors.New("invalid RSA private key specified")
 	}
 
-	if hf == crypto.Hash(0) {
+	if !isSupportedAlg(hf, rsaSupportedHashFuncs) {
 		return nil, errors.New("invalid hash function specified")
 	}
 
@@ -116,13 +116,13 @@ type RSAPKCS1v15Verifier struct {
 // LoadRSAPKCS1v15Verifier returns a Verifier that verifies signatures using the specified
 // RSA public key and hash algorithm.
 //
-// hf must not be crypto.Hash(0).
+// hf must be either SHA256, SHA388, or SHA512.
 func LoadRSAPKCS1v15Verifier(pub *rsa.PublicKey, hashFunc crypto.Hash) (*RSAPKCS1v15Verifier, error) {
 	if pub == nil {
 		return nil, errors.New("invalid RSA public key specified")
 	}
 
-	if hashFunc == crypto.Hash(0) {
+	if !isSupportedAlg(hashFunc, rsaSupportedHashFuncs) {
 		return nil, errors.New("invalid hash function specified")
 	}
 

--- a/pkg/signature/rsapkcs1v15_test.go
+++ b/pkg/signature/rsapkcs1v15_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -51,4 +52,15 @@ func TestRSAPKCS1v15SignerVerifier(t *testing.T) {
 		t.Errorf("unexpected error creating verifier: %v", err)
 	}
 	testingVerifier(t, v, "rsa", crypto.SHA256, sig, message)
+}
+
+func TestRSAPKCS1v15SignerVerifierUnsupportedHash(t *testing.T) {
+	publicKey, err := cryptoutils.UnmarshalPEMToPublicKey([]byte(pubKey))
+	if err != nil {
+		t.Errorf("unexpected error unmarshalling public key: %v", err)
+	}
+	_, err = LoadRSAPKCS1v15Verifier(publicKey.(*rsa.PublicKey), crypto.SHA1)
+	if !strings.Contains(err.Error(), "invalid hash function specified") {
+		t.Errorf("expected error 'invalid hash function specified', got: %v", err.Error())
+	}
 }

--- a/pkg/signature/rsapss.go
+++ b/pkg/signature/rsapss.go
@@ -27,10 +27,8 @@ import (
 
 var rsaSupportedHashFuncs = []crypto.Hash{
 	crypto.SHA256,
-	crypto.SHA512,
-	crypto.SHA224,
 	crypto.SHA384,
-	crypto.SHA1,
+	crypto.SHA512,
 }
 
 // RSAPSSSigner is a signature.Signer that uses the RSA PSS algorithm
@@ -45,7 +43,7 @@ type RSAPSSSigner struct {
 // If opts are specified, then they will be stored and used as a default if not overridden
 // by the value passed to Sign().
 //
-// hf must not be crypto.Hash(0).
+// hf must be either SHA256, SHA388, or SHA512. opts.Hash is ignored.
 func LoadRSAPSSSigner(priv *rsa.PrivateKey, hf crypto.Hash, opts *rsa.PSSOptions) (*RSAPSSSigner, error) {
 	if priv == nil {
 		return nil, errors.New("invalid RSA private key specified")
@@ -135,7 +133,7 @@ type RSAPSSVerifier struct {
 
 // LoadRSAPSSVerifier verifies signatures using the specified public key and hash algorithm.
 //
-// hf must not be crypto.Hash(0). opts.Hash is ignored.
+// hf must be either SHA256, SHA388, or SHA512. opts.Hash is ignored.
 func LoadRSAPSSVerifier(pub *rsa.PublicKey, hashFunc crypto.Hash, opts *rsa.PSSOptions) (*RSAPSSVerifier, error) {
 	if pub == nil {
 		return nil, errors.New("invalid RSA public key specified")

--- a/pkg/signature/rsapss_test.go
+++ b/pkg/signature/rsapss_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto"
 	"crypto/rsa"
 	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -108,4 +109,15 @@ func TestRSAPSSSignerVerifier(t *testing.T) {
 		t.Errorf("unexpected error creating verifier with nil opts: %v", err)
 	}
 	testingVerifier(t, v, "rsa", crypto.SHA256, sig, message)
+}
+
+func TestRSAPSSSignerVerifierUnsupportedHash(t *testing.T) {
+	publicKey, err := cryptoutils.UnmarshalPEMToPublicKey([]byte(pubKey))
+	if err != nil {
+		t.Errorf("unexpected error unmarshalling public key: %v", err)
+	}
+	_, err = LoadRSAPSSVerifier(publicKey.(*rsa.PublicKey), crypto.SHA1, nil)
+	if !strings.Contains(err.Error(), "invalid hash function specified") {
+		t.Errorf("expected error 'invalid hash function specified', got: %v", err.Error())
+	}
 }


### PR DESCRIPTION
This sets the set of supported hashes to SHA256, SHA384,
and SHA512. SHA1 should not be used for RSA-PKCS#1v1.5,
as it is not collision resistant. Not an expert on this,
but technically SHA1 is acceptable for RSA-PSS due to how
the hash function is used, as part of its
"mask generation function". However, since SHA1 is not
supported by cloud KMS services, we should just remove it entirely.
SHA224 is also not supported anywhere.

RSA-PKCS#1v1.5 was not enforcing the set of hashes on load.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Dropped support for SHA1 and SHA224 when signing and verifying with RSA-PKCS#1-v1.5 and RSA-PSS
```
