### PR TITLE
Fix minor typos for HashiCorp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This library currently provides:
 The following KMS systems are available:
 * AWS Key Management Service
 * Azure Key Vault
-* Hashivault Vault
+* HashiCorp Vault
 * Google Cloud Platform Key Management Service
 
 For example code, look at the relevant test code for each main code file.

--- a/pkg/signature/kms/hashivault/signer.go
+++ b/pkg/signature/kms/hashivault/signer.go
@@ -84,7 +84,7 @@ func LoadSignerVerifier(referenceStr string, hashFunc crypto.Hash) (*SignerVerif
 	return h, nil
 }
 
-// SignMessage signs the provided message using Hashivault KMS. If the message is provided,
+// SignMessage signs the provided message using HashiCorp Vault KMS. If the message is provided,
 // this method will compute the digest according to the hash function specified
 // when the HashivaultSigner was created.
 //


### PR DESCRIPTION
#### Summary
HashiCorp Vault is the preferred way to refer to the project. This fixes two text references (not code) references to that.

#### Release Note
None