### PR TITLE
Add subject key ID calculation from public key

### DIFF
--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -17,7 +17,10 @@ package cryptoutils
 
 import (
 	"crypto"
+	"crypto/sha1"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/pem"
 	"errors"
 )
@@ -26,6 +29,13 @@ const (
 	// PublicKeyPEMType is the string "PUBLIC KEY" to be used during PEM encoding and decoding
 	PublicKeyPEMType PEMType = "PUBLIC KEY"
 )
+
+// subjectPublicKeyInfo is used to construct a subject key ID.
+// https://tools.ietf.org/html/rfc5280#section-4.1.2.7
+type subjectPublicKeyInfo struct {
+	Algorithm        pkix.AlgorithmIdentifier
+	SubjectPublicKey asn1.BitString
+}
 
 // UnmarshalPEMToPublicKey converts a PEM-encoded byte slice into a crypto.PublicKey
 func UnmarshalPEMToPublicKey(pemBytes []byte) (crypto.PublicKey, error) {
@@ -51,4 +61,20 @@ func MarshalPublicKeyToPEM(pub crypto.PublicKey) ([]byte, error) {
 		return nil, err
 	}
 	return PEMEncode(PublicKeyPEMType, derBytes), nil
+}
+
+// SKID generates a 160-bit SHA-1 hash of the value of the BIT STRING
+// subjectPublicKey (excluding the tag, length, and number of unused bits).
+// https://tools.ietf.org/html/rfc5280#section-4.2.1.2
+func SKID(pub crypto.PublicKey) ([]byte, error) {
+	derPubBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+	var spki subjectPublicKeyInfo
+	if _, err := asn1.Unmarshal(derPubBytes, &spki); err != nil {
+		return nil, err
+	}
+	skid := sha1.Sum(spki.SubjectPublicKey.Bytes)
+	return skid[:], nil
 }

--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -17,7 +17,7 @@ package cryptoutils
 
 import (
 	"crypto"
-	"crypto/sha1"
+	"crypto/sha1" // nolint:gosec
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
@@ -75,6 +75,6 @@ func SKID(pub crypto.PublicKey) ([]byte, error) {
 	if _, err := asn1.Unmarshal(derPubBytes, &spki); err != nil {
 		return nil, err
 	}
-	skid := sha1.Sum(spki.SubjectPublicKey.Bytes)
+	skid := sha1.Sum(spki.SubjectPublicKey.Bytes) // nolint:gosec
 	return skid[:], nil
 }

--- a/pkg/cryptoutils/publickey_test.go
+++ b/pkg/cryptoutils/publickey_test.go
@@ -67,3 +67,48 @@ func TestRSAPublicKeyPEMRoundtrip(t *testing.T) {
 	}
 	verifyPublicKeyPEMRoundtrip(t, priv.Public())
 }
+
+func TestSKIDRSA(t *testing.T) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey failed: %v", err)
+	}
+	skid, err := SKID(priv.Public())
+	if err != nil {
+		t.Fatalf("SKID failed: %v", err)
+	}
+	// Expect SKID is 160 bits (20 bytes)
+	if len(skid) != 20 {
+		t.Fatalf("SKID failed: %v", skid)
+	}
+}
+
+func TestSKIDECDSA(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey failed: %v", err)
+	}
+	skid, err := SKID(priv.Public())
+	if err != nil {
+		t.Fatalf("SKID failed: %v", err)
+	}
+	// Expect SKID is 160 bits (20 bytes)
+	if len(skid) != 20 {
+		t.Fatalf("SKID failed: %v", skid)
+	}
+}
+
+func TestSKIDED25519(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("ed25519.GenerateKey failed: %v", err)
+	}
+	skid, err := SKID(pub)
+	if err != nil {
+		t.Fatalf("SKID failed: %v", err)
+	}
+	// Expect SKID is 160 bits (20 bytes)
+	if len(skid) != 20 {
+		t.Fatalf("SKID failed: %v", skid)
+	}
+}


### PR DESCRIPTION
This will be used by Fulcio to correctly calculate the
subject key ID (SKID), which is currently hardcoded.

nolint:gosec is required for the usage of SHA1. This is acceptable for SKID generation.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Added method to calculate subject key ID from public key
```
