### PR TITLE
Add oidc login to vault

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/vault/api v1.3.1
+	github.com/hashicorp/vault/api/auth/approle v0.1.1
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,11 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aUVgQGvangFWQ=
 github.com/hashicorp/vault/api v1.3.1 h1:pkDkcgTh47PRjY1NEFeofqR4W/HkNUi9qIakESO2aRM=
 github.com/hashicorp/vault/api v1.3.1/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
+github.com/hashicorp/vault/api/auth/approle v0.1.1 h1:R5yA+xcNvw1ix6bDuWOaLOq2L4L77zDCVsethNw97xQ=
+github.com/hashicorp/vault/api/auth/approle v0.1.1/go.mod h1:mHOLgh//xDx4dpqXoq6tS8Ob0FoCFWLU2ibJ26Lfmag=
 github.com/hashicorp/vault/sdk v0.3.0 h1:kR3dpxNkhh/wr6ycaJYqp6AFT/i2xaftbfnwZduTKEY=
 github.com/hashicorp/vault/sdk v0.3.0/go.mod h1:aZ3fNuL5VNydQk8GcLJ2TV8YCRVvyaakYkhZRoVuhj0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/pkg/signature/options.go
+++ b/pkg/signature/options.go
@@ -19,12 +19,15 @@ import (
 	"context"
 	"crypto"
 	"io"
+
+	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 // RPCOption specifies options to be used when performing RPC
 type RPCOption interface {
 	ApplyContext(*context.Context)
 	ApplyRemoteVerification(*bool)
+	ApplyRPCAuthOpts(opts *options.RPCAuth)
 }
 
 // PublicKeyOption specifies options to be used when obtaining a public key

--- a/pkg/signature/options/noop.go
+++ b/pkg/signature/options/noop.go
@@ -38,3 +38,6 @@ func (NoOpOptionImpl) ApplyRand(rand *io.Reader) {}
 
 // ApplyRemoteVerification is a no-op required to fully implement the requisite interfaces
 func (NoOpOptionImpl) ApplyRemoteVerification(remoteVerification *bool) {}
+
+// ApplyRPCAuthOpts is a no-op required to fully implement the requisite interfaces
+func (NoOpOptionImpl) ApplyRPCAuthOpts(opts *RPCAuth) {}

--- a/pkg/signature/options/rpcauth.go
+++ b/pkg/signature/options/rpcauth.go
@@ -1,0 +1,58 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+// RPCAuthOpts includes authentication settings for RPC calls
+type RPCAuthOpts struct {
+	NoOpOptionImpl
+	opts RPCAuth
+}
+
+// RPCAuth provides credentials for RPC calls, empty fields are ignored
+type RPCAuth struct {
+	Address string // address is the remote server address, e.g. https://vault:8200
+	Path    string // path for the RPC, in vault this is the transit path which default to "transit"
+	Token   string // token used for RPC, in vault this is the VAULT_TOKEN value
+	OIDC    RPCAuthOIDC
+}
+
+// RPCAuthOIDC is used to perform the RPC login using OIDC instead of a fixed token
+type RPCAuthOIDC struct {
+	Path  string // path defaults to "jwt" for vault
+	Role  string // role is required for jwt logins
+	Token string // token is a jwt with vault
+}
+
+// ApplyCryptoSignerOpts sets the RPCAuth as a function option
+func (r RPCAuthOpts) ApplyRPCAuthOpts(opts *RPCAuth) {
+	if r.opts.Address != "" {
+		opts.Address = r.opts.Address
+	}
+	if r.opts.Path != "" {
+		opts.Path = r.opts.Path
+	}
+	if r.opts.Token != "" {
+		opts.Token = r.opts.Token
+	}
+	if r.opts.OIDC.Token != "" {
+		opts.OIDC = r.opts.OIDC
+	}
+}
+
+// WithRPCAuthTokenOpts specifies RPCAuth settings to be used with RPC logins
+func WithRPCAuthOpts(opts RPCAuth) RPCAuthOpts {
+	return RPCAuthOpts{opts: opts}
+}

--- a/pkg/signature/options/rpcauth.go
+++ b/pkg/signature/options/rpcauth.go
@@ -36,7 +36,7 @@ type RPCAuthOIDC struct {
 	Token string // token is a jwt with vault
 }
 
-// ApplyCryptoSignerOpts sets the RPCAuth as a function option
+// ApplyRPCAuthOpts sets the RPCAuth as a function option
 func (r RPCAuthOpts) ApplyRPCAuthOpts(opts *RPCAuth) {
 	if r.opts.Address != "" {
 		opts.Address = r.opts.Address
@@ -52,7 +52,7 @@ func (r RPCAuthOpts) ApplyRPCAuthOpts(opts *RPCAuth) {
 	}
 }
 
-// WithRPCAuthTokenOpts specifies RPCAuth settings to be used with RPC logins
+// WithRPCAuthOpts specifies RPCAuth settings to be used with RPC logins
 func WithRPCAuthOpts(opts RPCAuth) RPCAuthOpts {
 	return RPCAuthOpts{opts: opts}
 }

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -33,7 +33,7 @@ docker-compose up -d
 count=0
 
 echo -n "waiting up to 60 sec for system to start"
-until [ $(docker-compose ps vault | grep -c "Up") == 1 -a $(docker-compose logs localstack | grep -c Ready) == 1 ];
+until [ $(docker-compose ps vault | grep -c -e "Up" -e "running") == 1 -a $(docker-compose logs localstack | grep -c Ready) == 1 ];
 do
     if [ $count -eq 12 ]; then
        echo "! timeout reached"


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
This adds the ability to login to vault using OIDC to get a token, and removes dependencies on environment variables.

I'm using this with Spire+OIDC to use Vault as a KMS without hard coding credentials in CI. Here's what that code looks like:

```golang
...
	kmsOpts := []signature.RPCOption{}
	rpcAuth := options.RPCAuth{
		Address: cfg.Auth.Address,
		OIDC: options.RPCAuthOIDC{
			Role: cfg.Auth.Role,
			Path: cfg.Auth.Path,
		},
	}
	jwtSource, err := workloadapi.NewJWTSource(
		ctx,
		workloadapi.WithClientOptions(workloadapi.WithAddr(cfg.Auth.Spire.Sock)),
	)
	if err != nil {
		return err
	}
	svid, err := jwtSource.FetchJWTSVID(ctx, jwtsvid.Params{Audience: cfg.Auth.Spire.Audience})
	if err != nil {
		return err
	}
	rpcAuth.OIDC.Token = svid.Marshal()
	kmsOpts = append(kmsOpts, options.WithRPCAuthOpts(rpcAuth))
	k, err := kms.Get(context.Background(), cfg.KMSRef, crypto.SHA256, kmsOpts...)
	if err != nil {
		return err
	}
...
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Adding ability to login to Vault using OIDC
```
