### PR TITLE
Add ability to specify key version for Hashivault

### DIFF
--- a/pkg/signature/options.go
+++ b/pkg/signature/options.go
@@ -28,6 +28,7 @@ type RPCOption interface {
 	ApplyContext(*context.Context)
 	ApplyRemoteVerification(*bool)
 	ApplyRPCAuthOpts(opts *options.RPCAuth)
+	ApplyKeyVersion(keyVersion *string)
 }
 
 // PublicKeyOption specifies options to be used when obtaining a public key

--- a/pkg/signature/options/keyversion.go
+++ b/pkg/signature/options/keyversion.go
@@ -1,0 +1,33 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+// RequestKeyVersion implements the functional option pattern for specifying the KMS key version during signing or verification
+type RequestKeyVersion struct {
+	NoOpOptionImpl
+	keyVersion string
+}
+
+// ApplyKeyVersion sets the KMS's key version as a functional option
+func (r RequestKeyVersion) ApplyKeyVersion(keyVersion *string) {
+	*keyVersion = r.keyVersion
+}
+
+// WithKeyVersion specifies that a specific KMS key version be used during signing and verification operations;
+// a value of 0 will use the latest version of the key (default)
+func WithKeyVersion(keyVersion string) RequestKeyVersion {
+	return RequestKeyVersion{keyVersion: keyVersion}
+}

--- a/pkg/signature/options/noop.go
+++ b/pkg/signature/options/noop.go
@@ -41,3 +41,6 @@ func (NoOpOptionImpl) ApplyRemoteVerification(remoteVerification *bool) {}
 
 // ApplyRPCAuthOpts is a no-op required to fully implement the requisite interfaces
 func (NoOpOptionImpl) ApplyRPCAuthOpts(opts *RPCAuth) {}
+
+// ApplyKeyVersion is a no-op required to fully implement the requisite interfaces
+func (NoOpOptionImpl) ApplyKeyVersion(keyVersion *string) {}

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build e2e
 // +build e2e
 
 package oauthflow


### PR DESCRIPTION
This adds a functional option to specify a key version to be used during signing and verification operations.

This partially addresses sigstore/cosign#1351

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>
