### PR TITLE
return version of Vault key via functional option

### DIFF
--- a/pkg/signature/options.go
+++ b/pkg/signature/options.go
@@ -47,6 +47,7 @@ type SignOption interface {
 	RPCOption
 	MessageOption
 	ApplyRand(*io.Reader)
+	ApplyKeyVersionUsed(**string)
 }
 
 // VerifyOption specifies options to be used when verifying a signature

--- a/pkg/signature/options/keyversion.go
+++ b/pkg/signature/options/keyversion.go
@@ -31,3 +31,19 @@ func (r RequestKeyVersion) ApplyKeyVersion(keyVersion *string) {
 func WithKeyVersion(keyVersion string) RequestKeyVersion {
 	return RequestKeyVersion{keyVersion: keyVersion}
 }
+
+type RequestKeyVersionUsed struct {
+	NoOpOptionImpl
+	keyVersionUsed *string
+}
+
+// ApplyKeyVersionUsed requests to store the KMS's key version that was used as a functional option
+func (r RequestKeyVersionUsed) ApplyKeyVersionUsed(keyVersionUsed **string) {
+	*keyVersionUsed = r.keyVersionUsed
+}
+
+// ReturnKeyVersionUsed specifies that the specific KMS key version that was used during signing should be stored
+// in the pointer provided
+func ReturnKeyVersionUsed(keyVersionUsed *string) RequestKeyVersionUsed {
+	return RequestKeyVersionUsed{keyVersionUsed: keyVersionUsed}
+}

--- a/pkg/signature/options/keyversion.go
+++ b/pkg/signature/options/keyversion.go
@@ -32,6 +32,7 @@ func WithKeyVersion(keyVersion string) RequestKeyVersion {
 	return RequestKeyVersion{keyVersion: keyVersion}
 }
 
+// RequestKeyVersionUsed implements the functional option pattern for obtaining the KMS key version used during signing
 type RequestKeyVersionUsed struct {
 	NoOpOptionImpl
 	keyVersionUsed *string

--- a/pkg/signature/options/noop.go
+++ b/pkg/signature/options/noop.go
@@ -44,3 +44,6 @@ func (NoOpOptionImpl) ApplyRPCAuthOpts(opts *RPCAuth) {}
 
 // ApplyKeyVersion is a no-op required to fully implement the requisite interfaces
 func (NoOpOptionImpl) ApplyKeyVersion(keyVersion *string) {}
+
+// ApplyKeyVersionUsed is a no-op required to fully implement the requisite interfaces
+func (NoOpOptionImpl) ApplyKeyVersionUsed(keyVersion **string) {}


### PR DESCRIPTION
This is a follow-on to #256 that allows a caller to request the signer write the version of the vault key used to sign the artifact in a `*string`. 

This also partially addresses sigstore/cosign#1351

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>
