### PR TITLE
refactor oidc provider interfaces

### DIFF
--- a/pkg/oauth2/oidc/idtoken.go
+++ b/pkg/oauth2/oidc/idtoken.go
@@ -1,0 +1,30 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oidc
+
+import (
+	"context"
+
+	coreoidc "github.com/coreos/go-oidc/v3/oidc"
+)
+
+// IDToken is an Open ID Connect ID Token.
+type IDToken coreoidc.IDToken
+
+// IDTokenGetter retrieves IDTokens.
+type IDTokenGetter interface {
+	// GetIDToken returns an *IDToken
+	GetIDToken(context.Context) (*IDToken, error)
+}

--- a/pkg/oauthflow/flow_test.go
+++ b/pkg/oauthflow/flow_test.go
@@ -16,6 +16,7 @@
 package oauthflow
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -26,7 +27,6 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2"
 )
 
@@ -83,6 +83,7 @@ func sendCodeAndState(t *testing.T, redirectURL *url.URL, code, state string) {
 }
 
 func TestStaticTokenGetter_GetIDToken(t *testing.T) {
+	ctx := context.Background()
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatal(err)
@@ -168,7 +169,7 @@ func TestStaticTokenGetter_GetIDToken(t *testing.T) {
 			stg := &StaticTokenGetter{
 				RawToken: token,
 			}
-			got, err := stg.GetIDToken(nil, oauth2.Config{})
+			got, err := stg.GetIDToken(ctx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StaticTokenGetter.GetIDToken() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
Refactor OIDC providers to take in request `Context` and require one-time configuration of oauth provider.

```release-note

```
