### PR TITLE
pkg/signature/kms doesn't depend on kms impls

### DIFF
--- a/pkg/signature/kms/aws/client.go
+++ b/pkg/signature/kms/aws/client.go
@@ -35,7 +35,14 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
+	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
 )
+
+func init() {
+	sigkms.AddProvider(ReferenceScheme, func(_ context.Context, keyResourceID string, _ crypto.Hash, _ ...signature.RPCOption) (sigkms.SignerVerifier, error) {
+		return LoadSignerVerifier(keyResourceID)
+	})
+}
 
 const (
 	cacheKey = "signer"

--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -35,7 +35,15 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/sigstore/sigstore/pkg/signature"
+	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
 )
+
+func init() {
+	sigkms.AddProvider(ReferenceScheme, func(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts ...signature.RPCOption) (sigkms.SignerVerifier, error) {
+		return LoadSignerVerifier(ctx, keyResourceID, hashFunc)
+	})
+}
 
 type azureVaultClient struct {
 	client    *keyvault.BaseClient

--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -35,8 +35,15 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
+
+func init() {
+	sigkms.AddProvider(ReferenceScheme, func(ctx context.Context, keyResourceID string, _ crypto.Hash, opts ...signature.RPCOption) (sigkms.SignerVerifier, error) {
+		return LoadSignerVerifier(ctx, keyResourceID)
+	})
+}
 
 //nolint:revive
 const (

--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -34,7 +34,14 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
 )
+
+func init() {
+	sigkms.AddProvider(ReferenceScheme, func(_ context.Context, keyResourceID string, hashFunc crypto.Hash, opts ...signature.RPCOption) (sigkms.SignerVerifier, error) {
+		return LoadSignerVerifier(keyResourceID, hashFunc, opts...)
+	})
+}
 
 type hashivaultClient struct {
 	client                  *vault.Client

--- a/pkg/signature/kms/kms.go
+++ b/pkg/signature/kms/kms.go
@@ -22,26 +22,7 @@ import (
 	"strings"
 
 	"github.com/sigstore/sigstore/pkg/signature"
-	"github.com/sigstore/sigstore/pkg/signature/kms/aws"
-	"github.com/sigstore/sigstore/pkg/signature/kms/azure"
-	"github.com/sigstore/sigstore/pkg/signature/kms/gcp"
-	"github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 )
-
-func init() {
-	providersMux.AddProvider(aws.ReferenceScheme, func(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts ...signature.RPCOption) (SignerVerifier, error) {
-		return aws.LoadSignerVerifier(keyResourceID)
-	})
-	providersMux.AddProvider(azure.ReferenceScheme, func(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts ...signature.RPCOption) (SignerVerifier, error) {
-		return azure.LoadSignerVerifier(ctx, keyResourceID, hashFunc)
-	})
-	providersMux.AddProvider(gcp.ReferenceScheme, func(ctx context.Context, keyResourceID string, _ crypto.Hash, opts ...signature.RPCOption) (SignerVerifier, error) {
-		return gcp.LoadSignerVerifier(ctx, keyResourceID)
-	})
-	providersMux.AddProvider(hashivault.ReferenceScheme, func(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts ...signature.RPCOption) (SignerVerifier, error) {
-		return hashivault.LoadSignerVerifier(keyResourceID, hashFunc, opts...)
-	})
-}
 
 type providerInit func(context.Context, string, crypto.Hash, ...signature.RPCOption) (SignerVerifier, error)
 
@@ -50,8 +31,8 @@ type providers struct {
 }
 
 // AddProvider adds the provider implementation into the local cache
-func (p *providers) AddProvider(keyResourceID string, init providerInit) {
-	p.providers[keyResourceID] = init
+func AddProvider(keyResourceID string, init providerInit) {
+	providersMux.providers[keyResourceID] = init
 }
 
 var providersMux = &providers{


### PR DESCRIPTION
#### Summary

Clients who want to enable specific kms implementations can import (or underscore-import) specific KMS impls they want, and otherwise don't have to depend on them.


#### Release Note

```release-note
Specific kms implementations that are needed must be explicitly imported for init-time setup.
```
