### PR TITLE
remove unmaintained test dependency with invalid license

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/sigstore/sigstore
 go 1.16
 
 require (
-	bou.ke/monkey v1.0.2
 	cloud.google.com/go/compute v1.1.0 // indirect
 	cloud.google.com/go/iam v0.1.1 // indirect
 	cloud.google.com/go/kms v1.3.0
@@ -13,6 +12,7 @@ require (
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/ReneKroon/ttlcache/v2 v2.11.0
+	github.com/agiledragon/gomonkey v2.0.2+incompatible
 	github.com/aws/aws-sdk-go v1.43.0
 	github.com/cenkalti/backoff/v3 v3.2.2 // indirect
 	github.com/coreos/go-oidc/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
-bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
-bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -122,6 +120,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/ReneKroon/ttlcache/v2 v2.11.0 h1:OvlcYFYi941SBN3v9dsDcC2N8vRxyHcCmJb3Vl4QMoM=
 github.com/ReneKroon/ttlcache/v2 v2.11.0/go.mod h1:mBxvsNY+BT8qLLd6CuAJubbKo6r0jh3nb5et22bbfGY=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
+github.com/agiledragon/gomonkey v2.0.2+incompatible h1:eXKi9/piiC3cjJD1658mEE2o3NjkJ5vDLgYjCQu0Xlw=
+github.com/agiledragon/gomonkey v2.0.2+incompatible/go.mod h1:2NGfXu1a80LLr2cmWXGBDaHEjb1idR6+FVlX5T3D9hw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/test/e2e/oauthflow/oauth_test.go
+++ b/test/e2e/oauthflow/oauth_test.go
@@ -22,8 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"bou.ke/monkey"
-
+	"github.com/agiledragon/gomonkey"
 	"github.com/go-rod/rod"
 	"github.com/sigstore/sigstore/pkg/oauthflow"
 	"github.com/skratchdot/open-golang/open"
@@ -38,11 +37,12 @@ type OAuthSuite struct {
 func (suite *OAuthSuite) TestOauthFlow() {
 	urlCh := make(chan string)
 
-	monkey.Patch(open.Run, func(input string) error {
+	// monkey patch this to not actually open a browser
+	patches := gomonkey.ApplyFunc(open.Run, func(input string) error {
 		urlCh <- input
 		return nil
 	})
-	defer monkey.UnpatchAll()
+	defer func() { patches.Reset() }()
 
 	go func() {
 		authCodeURL := <-urlCh


### PR DESCRIPTION
Per https://github.com/bouk/monkey/blob/master/LICENSE.md we shouldn't be using this library in our e2e OIDC testing.

There may be a more elegant way to do this without monkey patching, but this at least moves us to a library with an MIT license that is actively maintained.

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>
