### PR TITLE
update permissions for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,9 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ main ]
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Per https://github.com/github/codeql-action#usage we need to add `security-events: write` to the CodeSQL action now that the default permissions for the sigstore org are read-only.

Signed-off-by: Bob Callaway <bcallaway@google.com>