### PR TITLE
Enable the same golangci-lint rules as `cosign`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,14 +15,24 @@
 
 linters:
   enable:
+  - asciicheck
   - deadcode
+  - depguard
   - errcheck
+  - errorlint
   - gofmt
   - goimports
   - gosec
   - gocritic
+  - importas
+  - prealloc
   - revive
   - misspell
+  - stylecheck
+  - tparallel
+  - unconvert
+  - unparam
+  - whitespace
 output:
   uniq-by-line: false
 issues:


### PR DESCRIPTION
Copy-pasted from https://github.com/sigstore/cosign/blob/main/.golangci.yml