### PR TITLE
return immediately, without waiting for the operation in progress to complete

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -62,5 +62,5 @@ jobs:
 
       - name: Start cloudbuild job
         working-directory: ./src/github.com/sigstore/${{ inputs.repo }}
-        run: gcloud builds submit --no-source --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ inputs.release_tag }},_TOOL_ORG=sigstore,_TOOL_REPO=${{ inputs.repo }},_STORAGE_LOCATION=${{ inputs.repo }}-releases,_KEY_RING=${{ inputs.key_ring }},_KEY_NAME=${{ inputs.key_name }},_GITHUB_USER=sigstore-bot --project=${{ env.PROJECT_ID }}
+        run: gcloud builds submit --no-source --async --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ inputs.release_tag }},_TOOL_ORG=sigstore,_TOOL_REPO=${{ inputs.repo }},_STORAGE_LOCATION=${{ inputs.repo }}-releases,_KEY_RING=${{ inputs.key_ring }},_KEY_NAME=${{ inputs.key_name }},_GITHUB_USER=sigstore-bot --project=${{ env.PROJECT_ID }}
 


### PR DESCRIPTION
#### Summary
we should not stream the logs from the cloudbuild to the GitHub action job to avoid any possible leaks. 
so after the job is submitted it returns and completes the task

related to https://github.com/sigstore/fulcio/runs/5536478096?check_suite_focus=true the cloudbuild ran successfully but the svc account does not have permission to stream the logs, and then it failed.



#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
