### PR TITLE
Add utilities to parse Oauth2 access token HTTP responses

### DIFF
--- a/pkg/oauth/internal/token.go
+++ b/pkg/oauth/internal/token.go
@@ -1,0 +1,159 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// var for testing
+var currentTime = time.Now
+
+// tokenRespJSON is the struct representing the JSON form of a RFC6749 access token success response.
+// See: https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+type tokenRespJSON struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int    `json:"expires_in"`
+	Scope        string `json:"scope"`
+}
+
+func parseFormURLEncodedAccessTokenSuccess(body []byte) (token *oauth2.Token, err error) {
+	vals, err := url.ParseQuery(string(body))
+	if err != nil {
+		return nil, err
+	}
+
+	token = &oauth2.Token{
+		AccessToken:  vals.Get("access_token"),
+		TokenType:    vals.Get("token_type"),
+		RefreshToken: vals.Get("refresh_token"),
+	}
+	ei := vals.Get("expires_in")
+	if ei != "" {
+		expires, err := strconv.Atoi(ei)
+		if err != nil {
+			return nil, fmt.Errorf(`failed to parse "expires_in": %w`, err)
+		}
+		if expires != 0 {
+			token.Expiry = currentTime().Add(time.Duration(expires) * time.Second)
+		}
+	}
+	return token.WithExtra(vals), nil
+}
+
+func parseJSONAccessTokenSuccess(body []byte) (token *oauth2.Token, err error) {
+	var tj tokenRespJSON
+	if err = json.Unmarshal(body, &tj); err != nil {
+		return nil, err
+	}
+	token = &oauth2.Token{
+		AccessToken:  tj.AccessToken,
+		TokenType:    tj.TokenType,
+		RefreshToken: tj.RefreshToken,
+	}
+	if tj.ExpiresIn != 0 {
+		token.Expiry = currentTime().Add(time.Duration(tj.ExpiresIn) * time.Second)
+	}
+	raw := map[string]interface{}{}
+	if err = json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	return token.WithExtra(raw), nil
+}
+
+func parseAccessTokenSuccess(body []byte, contentType string) (token *oauth2.Token, err error) {
+	if contentType == "application/x-www-form-urlencoded" {
+		return parseFormURLEncodedAccessTokenSuccess(body)
+	}
+	return parseJSONAccessTokenSuccess(body)
+}
+
+// ErrorTokenResponse represents an RFC6749 access token error response.
+// See: https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+type ErrorTokenResponse struct {
+	Code        string `json:"error"`
+	Description string `json:"error_description,omitempty"`
+	URI         string `json:"error_uri,omitempty"`
+}
+
+// Error implements `error`
+func (e *ErrorTokenResponse) Error() string {
+	str, _ := json.Marshal(e)
+	return string(str)
+}
+
+func parseFormURLEncodedAccessTokenError(body []byte) (*ErrorTokenResponse, error) {
+	vals, parseErr := url.ParseQuery(string(body))
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	return &ErrorTokenResponse{
+		Code:        vals.Get("error"),
+		Description: vals.Get("error_description"),
+		URI:         vals.Get("error_uri"),
+	}, nil
+}
+
+func parseJSONAccessTokenError(body []byte) (respErr *ErrorTokenResponse, parseErr error) {
+	var ej ErrorTokenResponse
+	if parseErr = json.Unmarshal(body, &ej); parseErr != nil {
+		return nil, parseErr
+	}
+	return &ej, nil
+}
+
+func parseAccessTokenError(body []byte, contentType string) (respErr *ErrorTokenResponse, parseErr error) {
+	if contentType == "application/x-www-form-urlencoded" {
+		return parseFormURLEncodedAccessTokenError(body)
+	}
+	return parseJSONAccessTokenError(body)
+}
+
+// ParseAccessTokenResponse parses an RFC6749 access token response and returns either an `*oauth2.Token` on success, an `*ErrorTokenResponse` on failure, or any other error if the response cannot be parsed.
+// See: https://datatracker.ietf.org/doc/html/rfc6749#section-5
+func ParseAccessTokenResponse(tokenResp *http.Response) (token *oauth2.Token, err error) {
+	body, err := ioutil.ReadAll(io.LimitReader(tokenResp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	contentType, _, _ := mime.ParseMediaType(tokenResp.Header.Get("Content-Type"))
+	if tokenResp.StatusCode != http.StatusOK {
+		respErr, parseErr := parseAccessTokenError(body, contentType)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		return nil, respErr
+	}
+	token, err = parseAccessTokenSuccess(body, contentType)
+	if err != nil {
+		return nil, err
+	}
+	if token.AccessToken == "" {
+		return nil, fmt.Errorf(`response did not contain "access_token". Content-Type: %q, Body: %s`, contentType, string(body))
+	}
+	return token, nil
+}

--- a/pkg/oauth/internal/token_test.go
+++ b/pkg/oauth/internal/token_test.go
@@ -1,0 +1,231 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestParseAccessTokenSuccessResponse(t *testing.T) {
+	now := currentTime()
+	realCurrentTime := currentTime
+	currentTime = func() time.Time { return now }
+	defer func() { currentTime = realCurrentTime }()
+
+	testCases := []struct {
+		desc            string
+		respContentType string
+		respBody        []byte
+
+		wantAccessToken  string
+		wantRefreshToken string
+		wantTokenType    string
+		wantExpiry       time.Time
+		mustHaveExtras   map[string]interface{}
+
+		wantError error
+	}{
+		{
+			desc: "json",
+
+			respContentType: "application/json",
+			respBody: []byte(`{
+				"access_token": "json access_token",
+				"token_type": "Bearer",
+				"refresh_token": "json refresh_token",
+				"expires_in": 3600,
+				"scope": "foo bar"
+			}`),
+
+			wantAccessToken:  "json access_token",
+			wantRefreshToken: "json refresh_token",
+			wantTokenType:    "Bearer",
+			wantExpiry:       now.Add(3600 * time.Second),
+			mustHaveExtras: map[string]interface{}{
+				"scope": "foo bar",
+			},
+		},
+		{
+			desc: "json no access_token",
+
+			respContentType: "application/json",
+			respBody:        []byte(`{"token_type":"Bearer","expires_in":3600,"scope":"foo bar"}`),
+
+			wantError: fmt.Errorf(`response did not contain "access_token". Content-Type: %q, Body: %s`, "application/json", `{"token_type":"Bearer","expires_in":3600,"scope":"foo bar"}`),
+		},
+		{
+			desc: "bad json",
+
+			respContentType: "application/json",
+			respBody:        []byte(`"token_type":"Bearer","expires_in":3600,"scope":"foo bar"`),
+
+			wantError: errors.New("invalid character ':' after top-level value"),
+		},
+		{
+			desc: "x-www-form-urlencoded",
+
+			respContentType: "application/x-www-form-urlencoded",
+			respBody: []byte(url.Values{
+				"access_token":  []string{"urlencoded access_token"},
+				"token_type":    []string{"MAC"},
+				"refresh_token": []string{"urlencoded refresh_token"},
+				"expires_in":    []string{"420"},
+				"scope":         []string{"bar baz"},
+			}.Encode()),
+
+			wantAccessToken:  "urlencoded access_token",
+			wantRefreshToken: "urlencoded refresh_token",
+			wantTokenType:    "MAC",
+			wantExpiry:       now.Add(420 * time.Second),
+			mustHaveExtras: map[string]interface{}{
+				"scope": "bar baz",
+			},
+		},
+		{
+			desc: "expires_in unparsable",
+
+			respContentType: "application/x-www-form-urlencoded",
+			respBody: []byte(url.Values{
+				"access_token": []string{"urlencoded access_token"},
+				"token_type":   []string{"Bearer"},
+				"expires_in":   []string{"unparsable"},
+			}.Encode()),
+
+			wantError: errors.New("failed to parse \"expires_in\": strconv.Atoi: parsing \"unparsable\": invalid syntax"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			testResp := &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(tc.respBody)),
+			}
+			if tc.respContentType != "" {
+				testResp.Header = make(http.Header, 1)
+				testResp.Header.Set("Content-Type", tc.respContentType)
+			}
+
+			token, err := ParseAccessTokenResponse(testResp)
+			if err == nil && tc.wantError != nil {
+				t.Fatalf("ParseAccessTokenResponse should have returned an error, got %v", token)
+			}
+			if err != nil {
+				if tc.wantError != nil {
+					gotErr := err.Error()
+					wantErr := tc.wantError.Error()
+					if gotErr != wantErr {
+						t.Fatalf("ParseAccessTokenResponse should have returned error %q, got %q", wantErr, gotErr)
+					}
+					return
+				}
+				t.Fatalf("ParseAccessTokenResponse returned error: %v", err)
+			}
+			if token.AccessToken != tc.wantAccessToken {
+				t.Errorf("Wanted AccessToken %q, got %q", tc.wantAccessToken, token.AccessToken)
+			}
+			if token.RefreshToken != tc.wantRefreshToken {
+				t.Errorf("Wanted RefreshToken %q, got %q", tc.wantRefreshToken, token.RefreshToken)
+			}
+			if token.TokenType != tc.wantTokenType {
+				t.Errorf("Wanted TokenType %q, got %q", tc.wantTokenType, token.TokenType)
+			}
+			if token.Expiry != tc.wantExpiry {
+				t.Errorf("Wanted Expiry %v, got %v", tc.wantExpiry, token.Expiry)
+			}
+			for k, v := range tc.mustHaveExtras {
+				gotVal := token.Extra(k)
+				if !reflect.DeepEqual(v, gotVal) {
+					t.Errorf("Wanted Extra(%q)=%v, got %v", k, v, gotVal)
+				}
+			}
+		})
+	}
+}
+
+func TestParseAccessTokenFailResponse(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		respStatusCode  int
+		respContentType string
+		respBody        []byte
+
+		wantError error
+	}{
+		{
+			desc: "json",
+
+			respStatusCode:  http.StatusBadRequest,
+			respContentType: "application/json",
+			respBody:        []byte(`{"error":"invalid_request","error_description":"description of error","error_uri":"https://test.example.com/json"}`),
+
+			wantError: &ErrorTokenResponse{
+				Code:        "invalid_request",
+				Description: "description of error",
+				URI:         "https://test.example.com/json",
+			},
+		},
+		{
+			desc: "x-www-form-urlencoded",
+
+			respStatusCode:  http.StatusBadRequest,
+			respContentType: "application/x-www-form-urlencoded",
+			respBody: []byte(url.Values{
+				"error":             []string{"invalid_request"},
+				"error_description": []string{"description of error"},
+				"error_uri":         []string{"https://test.example.com/form-urlencoded"},
+			}.Encode()),
+
+			wantError: &ErrorTokenResponse{
+				Code:        "invalid_request",
+				Description: "description of error",
+				URI:         "https://test.example.com/form-urlencoded",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			testResp := &http.Response{
+				StatusCode: tc.respStatusCode,
+				Body:       ioutil.NopCloser(bytes.NewReader(tc.respBody)),
+			}
+			if tc.respContentType != "" {
+				testResp.Header = make(http.Header, 1)
+				testResp.Header.Set("Content-Type", tc.respContentType)
+			}
+
+			token, err := ParseAccessTokenResponse(testResp)
+			if err == nil {
+				t.Fatalf("ParseAccessTokenResponse should have failed, got: %v", token)
+			}
+
+			gotErr := err.Error()
+			wantErr := tc.wantError.Error()
+
+			if gotErr != wantErr {
+				t.Errorf("ParseAccessTokenResponse should have returned error %q, got %q", wantErr, gotErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These helper utilities implement https://datatracker.ietf.org/doc/html/rfc6749#section-5 and are used in the creation of custom `oauth2.TokenSource`s.

Part of Fulcio-related work for https://github.com/sigstore/cosign/issues/844

```release-note
NONE
```
