### PR TITLE
Make tag,key_ring,key optional for release workflow.

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -4,15 +4,16 @@ on:
   workflow_call:
     inputs:
       release_tag:
-        required: true
+        required: false
         type: string
-        description: 'Release tag'
+        description: 'Release tag. Will increment patch version if not specified.'
+        default: ''
       key_ring:
-        required: true
+        required: false
         type: string
         description: 'Key ring for cosign key'
       key_name:
-        required: true
+        required: false
         type: string
         description: 'Key name for cosign key'
       workload_identity_provider:
@@ -38,6 +39,7 @@ jobs:
       contents: read
     env:
       PROJECT_ID: 'projectsigstore'
+      RELEASE_TAG: ${{ inputs.release_tag }}
     steps:
       - name: Check actor access
         if: ${{ !contains( fromJson('["bobcallaway","cpanato","dlorenc","lukehinds"]'), github.actor ) }}
@@ -47,6 +49,15 @@ jobs:
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
         with:
           path: ./src/github.com/sigstore/${{ inputs.repo }}
+
+      - name: Set release tag if not specified
+        if: ${{ inputs.release_tag = '' }}
+        run: |
+          git fetch --all --tags
+          LATEST_DIGEST=`git rev-list --tags --max-count=1`
+          LATEST_TAG=`git describe --tags ${LATEST_DIGEST}`
+          NEW_VERSION=`echo "${TAG}" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g'`
+          echo "RELEASE_TAG=${NEW_VERSION}" >> $GITHUB_ENV
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@8d125895b958610ec414ca4dae010257eaa814d3 # v0.6.0
@@ -62,5 +73,5 @@ jobs:
 
       - name: Start cloudbuild job
         working-directory: ./src/github.com/sigstore/${{ inputs.repo }}
-        run: gcloud builds submit --no-source --async --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ inputs.release_tag }},_TOOL_ORG=sigstore,_TOOL_REPO=${{ inputs.repo }},_STORAGE_LOCATION=${{ inputs.repo }}-releases,_KEY_RING=${{ inputs.key_ring }},_KEY_NAME=${{ inputs.key_name }},_GITHUB_USER=sigstore-bot --project=${{ env.PROJECT_ID }}
+        run: gcloud builds submit --no-source --async --config release/cloudbuild.yaml --substitutions _GIT_TAG=${{ env.RELEASE_TAG },_TOOL_ORG=sigstore,_TOOL_REPO=${{ inputs.repo }},_STORAGE_LOCATION=${{ inputs.repo }}-releases,_KEY_RING=release-cosign,_KEY_NAME=cosign,_GITHUB_USER=sigstore-bot --project=${{ env.PROJECT_ID }}
 


### PR DESCRIPTION


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
Make tag,key_ring,key optional for release workflow.

This is make it possible to cut releases completely automatically.

The tag will now increment the patch value by one if the release tag is
not specified.
For example:
- 1.5.9 => 1.5.10

Keyring and Key value from GCP project are now hardcoded.

Will remove the input key_ring and key when it dependent workflows are
updated to no longer specify them.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

towards fixing https://github.com/sigstore/public-good-instance/issues/50

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
