### PR TITLE
add oidc callback port flag to use a specific port instead of random (0)

### DIFF
--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -125,7 +125,7 @@ func (idts *interactiveIDTokenSource) IDToken(ctx context.Context) (*IDToken, er
 	codeCh := make(chan string)
 	errCh := make(chan error)
 	// starts listener on ephemeral port
-	redirectServer, redirectURL, err := startRedirectListener(stateToken, oauth.InteractiveSuccessHTML, codeCh, errCh)
+	redirectServer, redirectURL, err := startRedirectListener(stateToken, oauth.InteractiveSuccessHTML, 0, codeCh, errCh)
 	if err != nil {
 		close(codeCh)
 		close(errCh)

--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -45,8 +45,8 @@ func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOpti
 	return code
 }
 
-func startRedirectListener(state, htmlPage string, codeCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
-	listener, err := net.Listen("tcp", "localhost:0") // ":0" == OS picks
+func startRedirectListener(state, htmlPage string, oidcCallbackPort int, codeCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", oidcCallbackPort))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/oauthflow/flow_test.go
+++ b/pkg/oauthflow/flow_test.go
@@ -39,7 +39,7 @@ func TestGetCodeWorking(t *testing.T) {
 	var gotErr error
 	doneCh := make(chan string)
 	errCh := make(chan error)
-	_, url, _ := startRedirectListener(desiredState, "", doneCh, errCh)
+	_, url, _ := startRedirectListener(desiredState, "", 0, doneCh, errCh)
 	go func() {
 		gotCode, gotErr = getCode(doneCh, errCh)
 	}()
@@ -62,7 +62,7 @@ func TestGetCodeWrongState(t *testing.T) {
 	var gotErr error
 	doneCh := make(chan string)
 	errCh := make(chan error)
-	_, u, _ := startRedirectListener(desiredState, "", doneCh, errCh)
+	_, u, _ := startRedirectListener(desiredState, "", 0, doneCh, errCh)
 	go func() {
 		_, gotErr = getCode(doneCh, errCh)
 	}()


### PR DESCRIPTION
Signed-off-by: Tuan Anh Tran <anhtt17@techcombank.com.vn>

Require another PR at cosign project. https://github.com/sigstore/cosign/pull/1658


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Allow to set callback port to a specific port instead of the random one (0) currently. this is a litmitation of some provider that do callback url whitelisting.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/cosign/issues/1105

-->
Fixes https://github.com/sigstore/cosign/issues/1105

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
