### PR TITLE
oidc: set the redirect url if needed

### DIFF
--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -45,12 +45,12 @@ func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOpti
 	return code
 }
 
-func startRedirectListener(state, htmlPage, redirectURI string, codeCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
+func startRedirectListener(state, htmlPage, redirectURL string, codeCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
 	var listener net.Listener
 	var urlListener *url.URL
 	var err error
 
-	if redirectURI == "" {
+	if redirectURL == "" {
 		listener, err = net.Listen("tcp", "localhost:0") // ":0" == OS picks
 		if err != nil {
 			return nil, nil, err
@@ -63,7 +63,7 @@ func startRedirectListener(state, htmlPage, redirectURI string, codeCh chan stri
 			Path:   "/auth/callback",
 		}
 	} else {
-		urlListener, err = url.Parse(redirectURI)
+		urlListener, err = url.Parse(redirectURL)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -138,7 +138,7 @@ func (idts *interactiveIDTokenSource) IDToken(ctx context.Context) (*IDToken, er
 
 	codeCh := make(chan string)
 	errCh := make(chan error)
-	// starts listener using the redirect_uri, otherwise stars on ephemeral port
+	// starts listener using the redirect_uri, otherwise starts on ephemeral port
 	redirectServer, redirectURL, err := startRedirectListener(stateToken, oauth.InteractiveSuccessHTML, cfg.RedirectURL, codeCh, errCh)
 	if err != nil {
 		close(codeCh)

--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -45,27 +45,41 @@ func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOpti
 	return code
 }
 
-func startRedirectListener(state, htmlPage string, codeCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
-	listener, err := net.Listen("tcp", "localhost:0") // ":0" == OS picks
-	if err != nil {
-		return nil, nil, err
-	}
+func startRedirectListener(state, htmlPage, redirectURI string, codeCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
+	var listener net.Listener
+	var urlListener *url.URL
+	var err error
 
-	port := listener.Addr().(*net.TCPAddr).Port
+	if redirectURI == "" {
+		listener, err = net.Listen("tcp", "localhost:0") // ":0" == OS picks
+		if err != nil {
+			return nil, nil, err
+		}
 
-	url := &url.URL{
-		Scheme: "http",
-		Host:   fmt.Sprintf("localhost:%d", port),
-		Path:   "/auth/callback",
+		port := listener.Addr().(*net.TCPAddr).Port
+		urlListener = &url.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("localhost:%d", port),
+			Path:   "/auth/callback",
+		}
+	} else {
+		urlListener, err = url.Parse(redirectURI)
+		if err != nil {
+			return nil, nil, err
+		}
+		listener, err = net.Listen("tcp", urlListener.Host)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	m := http.NewServeMux()
 	s := &http.Server{
-		Addr:    url.Host,
+		Addr:    urlListener.Host,
 		Handler: m,
 	}
 
-	m.HandleFunc(url.Path, func(w http.ResponseWriter, r *http.Request) {
+	m.HandleFunc(urlListener.Path, func(w http.ResponseWriter, r *http.Request) {
 		// even though these are fetched from the FormValue method,
 		// these are supplied as query parameters
 		if r.FormValue("state") != state {
@@ -82,7 +96,7 @@ func startRedirectListener(state, htmlPage string, codeCh chan string, errCh cha
 		}
 	}()
 
-	return s, url, nil
+	return s, urlListener, nil
 }
 
 func getCode(codeCh chan string, errCh chan error) (string, error) {
@@ -124,8 +138,8 @@ func (idts *interactiveIDTokenSource) IDToken(ctx context.Context) (*IDToken, er
 
 	codeCh := make(chan string)
 	errCh := make(chan error)
-	// starts listener on ephemeral port
-	redirectServer, redirectURL, err := startRedirectListener(stateToken, oauth.InteractiveSuccessHTML, codeCh, errCh)
+	// starts listener using the redirect_uri, otherwise stars on ephemeral port
+	redirectServer, redirectURL, err := startRedirectListener(stateToken, oauth.InteractiveSuccessHTML, cfg.RedirectURL, codeCh, errCh)
 	if err != nil {
 		close(codeCh)
 		close(errCh)

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -72,12 +72,12 @@ func NewDeviceFlowTokenGetter(issuer, codeURL, tokenURL string) *DeviceFlowToken
 }
 
 func (d *DeviceFlowTokenGetter) deviceFlow(clientID, redirectURI string) (string, error) {
-
 	data := url.Values{
 		"client_id": []string{clientID},
 		"scope":     []string{"openid email"},
 	}
 	if redirectURI != "" {
+		// If a redirect uri is provided then use it
 		data["redirect_uri"] = []string{redirectURI}
 	}
 

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -71,10 +71,14 @@ func NewDeviceFlowTokenGetter(issuer, codeURL, tokenURL string) *DeviceFlowToken
 	}
 }
 
-func (d *DeviceFlowTokenGetter) deviceFlow(clientID string) (string, error) {
+func (d *DeviceFlowTokenGetter) deviceFlow(clientID, redirectURI string) (string, error) {
+
 	data := url.Values{
 		"client_id": []string{clientID},
 		"scope":     []string{"openid email"},
+	}
+	if redirectURI != "" {
+		data["redirect_uri"] = []string{redirectURI}
 	}
 
 	/* #nosec */
@@ -140,7 +144,7 @@ func (d *DeviceFlowTokenGetter) deviceFlow(clientID string) (string, error) {
 
 // GetIDToken gets an OIDC ID Token from the specified provider using the device code grant flow
 func (d *DeviceFlowTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Config) (*OIDCIDToken, error) {
-	idToken, err := d.deviceFlow(cfg.ClientID)
+	idToken, err := d.deviceFlow(cfg.ClientID, cfg.RedirectURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -71,14 +71,14 @@ func NewDeviceFlowTokenGetter(issuer, codeURL, tokenURL string) *DeviceFlowToken
 	}
 }
 
-func (d *DeviceFlowTokenGetter) deviceFlow(clientID, redirectURI string) (string, error) {
+func (d *DeviceFlowTokenGetter) deviceFlow(clientID, redirectURL string) (string, error) {
 	data := url.Values{
 		"client_id": []string{clientID},
 		"scope":     []string{"openid email"},
 	}
-	if redirectURI != "" {
+	if redirectURL != "" {
 		// If a redirect uri is provided then use it
-		data["redirect_uri"] = []string{redirectURI}
+		data["redirect_uri"] = []string{redirectURL}
 	}
 
 	/* #nosec */

--- a/pkg/oauthflow/device_test.go
+++ b/pkg/oauthflow/device_test.go
@@ -71,7 +71,7 @@ func TestDeviceFlowTokenGetter_deviceFlow(t *testing.T) {
 
 	tokenCh, errCh := make(chan string), make(chan error)
 	go func() {
-		token, err := dtg.deviceFlow("sigstore")
+		token, err := dtg.deviceFlow("sigstore", "")
 		tokenCh <- token
 		errCh <- err
 	}()

--- a/pkg/oauthflow/e2e_test.go
+++ b/pkg/oauthflow/e2e_test.go
@@ -51,6 +51,7 @@ func (suite *OAuthSuite) TestOauthFlow() {
 		os.Getenv("OIDC_ISSUER"),
 		os.Getenv("OIDC_ID"),
 		"",
+		"",
 		DefaultIDTokenGetter,
 	)
 

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -94,7 +94,7 @@ var PublicInstanceMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
 }
 
 // OIDConnect requests an OIDC Identity Token from the specified issuer using the specified client credentials and TokenGetter
-func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCIDToken, error) {
+func OIDConnect(issuer string, id string, secret string, redirectURI string, tg TokenGetter) (*OIDCIDToken, error) {
 	provider, err := oidc.NewProvider(context.Background(), issuer)
 	if err != nil {
 		return nil, err
@@ -104,6 +104,7 @@ func OIDConnect(issuer string, id string, secret string, tg TokenGetter) (*OIDCI
 		ClientSecret: secret,
 		Endpoint:     provider.Endpoint(),
 		Scopes:       []string{oidc.ScopeOpenID, "email"},
+		RedirectURL:  redirectURI,
 	}
 
 	return tg.GetIDToken(provider, config)

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -94,7 +94,8 @@ var PublicInstanceMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
 }
 
 // OIDConnect requests an OIDC Identity Token from the specified issuer using the specified client credentials and TokenGetter
-func OIDConnect(issuer string, id string, secret string, redirectURI string, tg TokenGetter) (*OIDCIDToken, error) {
+// NOTE: If the redirectURL is empty a listener on localhost:0 is configured with '/auth/callback' as default path.
+func OIDConnect(issuer string, id string, secret string, redirectURL string, tg TokenGetter) (*OIDCIDToken, error) {
 	provider, err := oidc.NewProvider(context.Background(), issuer)
 	if err != nil {
 		return nil, err
@@ -104,7 +105,7 @@ func OIDConnect(issuer string, id string, secret string, redirectURI string, tg 
 		ClientSecret: secret,
 		Endpoint:     provider.Endpoint(),
 		Scopes:       []string{oidc.ScopeOpenID, "email"},
-		RedirectURL:  redirectURI,
+		RedirectURL:  redirectURL,
 	}
 
 	return tg.GetIDToken(provider, config)

--- a/pkg/oauthflow/flow_test.go
+++ b/pkg/oauthflow/flow_test.go
@@ -39,7 +39,7 @@ func TestGetCodeWorking(t *testing.T) {
 	var gotErr error
 	doneCh := make(chan string)
 	errCh := make(chan error)
-	_, url, _ := startRedirectListener(desiredState, "", doneCh, errCh)
+	_, url, _ := startRedirectListener(desiredState, "", "", doneCh, errCh)
 	go func() {
 		gotCode, gotErr = getCode(doneCh, errCh)
 	}()
@@ -62,7 +62,7 @@ func TestGetCodeWrongState(t *testing.T) {
 	var gotErr error
 	doneCh := make(chan string)
 	errCh := make(chan error)
-	_, u, _ := startRedirectListener(desiredState, "", doneCh, errCh)
+	_, u, _ := startRedirectListener(desiredState, "", "", doneCh, errCh)
 	go func() {
 		_, gotErr = getCode(doneCh, errCh)
 	}()

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -50,8 +50,8 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 
 	doneCh := make(chan string)
 	errCh := make(chan error)
-	// starts listener on ephemeral port
-	redirectServer, redirectURL, err := startRedirectListener(stateToken, i.HTMLPage, doneCh, errCh)
+	// starts listener using the redirect_uri, otherwise stars on ephemeral port
+	redirectServer, redirectURL, err := startRedirectListener(stateToken, i.HTMLPage, cfg.RedirectURL, doneCh, errCh)
 	if err != nil {
 		return nil, errors.Wrap(err, "starting redirect listener")
 	}
@@ -135,27 +135,42 @@ func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOpti
 	return code
 }
 
-func startRedirectListener(state, htmlPage string, doneCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
-	listener, err := net.Listen("tcp", "localhost:0")
-	if err != nil {
-		return nil, nil, err
-	}
+func startRedirectListener(state, htmlPage, redirectURI string, doneCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
+	var listener net.Listener
+	var urlListener *url.URL
+	var err error
 
-	port := listener.Addr().(*net.TCPAddr).Port
+	if redirectURI == "" {
+		listener, err = net.Listen("tcp", "localhost:0")
+		if err != nil {
+			return nil, nil, err
+		}
 
-	url := &url.URL{
-		Scheme: "http",
-		Host:   fmt.Sprintf("localhost:%d", port),
-		Path:   "/auth/callback",
+		port := listener.Addr().(*net.TCPAddr).Port
+		urlListener = &url.URL{
+			Scheme: "http",
+			Host:   fmt.Sprintf("localhost:%d", port),
+			Path:   "/auth/callback",
+		}
+	} else {
+		urlListener, err = url.Parse(redirectURI)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		listener, err = net.Listen("tcp", urlListener.Host)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 
 	m := http.NewServeMux()
 	s := &http.Server{
-		Addr:    url.Host,
+		Addr:    urlListener.Host,
 		Handler: m,
 	}
 
-	m.HandleFunc(url.Path, func(w http.ResponseWriter, r *http.Request) {
+	m.HandleFunc(urlListener.Path, func(w http.ResponseWriter, r *http.Request) {
 		// even though these are fetched from the FormValue method,
 		// these are supplied as query parameters
 		if r.FormValue("state") != state {
@@ -172,7 +187,7 @@ func startRedirectListener(state, htmlPage string, doneCh chan string, errCh cha
 		}
 	}()
 
-	return s, url, nil
+	return s, urlListener, nil
 }
 
 func getCode(doneCh chan string, errCh chan error) (string, error) {

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -50,7 +50,7 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 
 	doneCh := make(chan string)
 	errCh := make(chan error)
-	// starts listener using the redirect_uri, otherwise stars on ephemeral port
+	// starts listener using the redirect_uri, otherwise starts on ephemeral port
 	redirectServer, redirectURL, err := startRedirectListener(stateToken, i.HTMLPage, cfg.RedirectURL, doneCh, errCh)
 	if err != nil {
 		return nil, errors.Wrap(err, "starting redirect listener")

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -135,12 +135,12 @@ func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOpti
 	return code
 }
 
-func startRedirectListener(state, htmlPage, redirectURI string, doneCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
+func startRedirectListener(state, htmlPage, redirectURL string, doneCh chan string, errCh chan error) (*http.Server, *url.URL, error) {
 	var listener net.Listener
 	var urlListener *url.URL
 	var err error
 
-	if redirectURI == "" {
+	if redirectURL == "" {
 		listener, err = net.Listen("tcp", "localhost:0")
 		if err != nil {
 			return nil, nil, err
@@ -153,7 +153,7 @@ func startRedirectListener(state, htmlPage, redirectURI string, doneCh chan stri
 			Path:   "/auth/callback",
 		}
 	} else {
-		urlListener, err = url.Parse(redirectURI)
+		urlListener, err = url.Parse(redirectURL)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

When using certain OIDC providers, you might need to set a specific `redirect_uri`. This implementation defaults to the old mechanism setting a listener on localhost and letting the OS to pick a port if the `redirect_uri` is not set.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes https://github.com/sigstore/cosign/issues/1105 and https://github.com/sigstore/cosign/issues/1311

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
oauthflow: accept a pre-defined redirect_uri.
```
