### PR TITLE
Add fake signer that implements KMS interface

### DIFF
--- a/pkg/signature/kms/fake/signer.go
+++ b/pkg/signature/kms/fake/signer.go
@@ -1,0 +1,134 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"crypto"
+	"io"
+
+	"github.com/sigstore/sigstore/pkg/signature"
+	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
+	"github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+// SignerVerifier creates and verifies digital signatures over a message using an in-memory signer
+type SignerVerifier struct {
+	signer *signature.ECDSASignerVerifier
+}
+
+// ReferenceScheme is a scheme for fake KMS keys. Do not use in production.
+const ReferenceScheme = "fakekms://"
+
+func init() {
+	sigkms.AddProvider(ReferenceScheme, func(_ context.Context, _ string, _ crypto.Hash, _ ...signature.RPCOption) (sigkms.SignerVerifier, error) {
+		return LoadSignerVerifier()
+	})
+}
+
+// LoadSignerVerifier generates signatures using the default ECDSA signer.
+func LoadSignerVerifier() (*SignerVerifier, error) {
+	signer, _, err := signature.NewDefaultECDSASignerVerifier()
+	if err != nil {
+		return nil, err
+	}
+	g := &SignerVerifier{
+		signer: signer,
+	}
+	return g, nil
+}
+
+// SignMessage signs the provided message using the in-memory -signer.
+func (g *SignerVerifier) SignMessage(message io.Reader, opts ...signature.SignOption) ([]byte, error) {
+	return g.signer.SignMessage(message, opts...)
+}
+
+// PublicKey returns the public key that can be used to verify signatures created by
+// this signer.
+func (g *SignerVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return g.signer.PublicKey(opts...)
+}
+
+// VerifySignature verifies the signature for the given message. Unless provided
+// in an option, the digest of the message will be computed using the hash function specified
+// when the SignerVerifier was created.
+//
+// This function returns nil if the verification succeeded, and an error message otherwise.
+//
+// This function recognizes the following Options listed in order of preference:
+//
+// - WithDigest()
+//
+// All other options are ignored if specified.
+func (g *SignerVerifier) VerifySignature(signature, message io.Reader, opts ...signature.VerifyOption) error {
+	return g.signer.VerifySignature(signature, message, opts...)
+}
+
+// CreateKey returns the signer's public key.
+func (g *SignerVerifier) CreateKey(etx context.Context, algorithm string) (crypto.PublicKey, error) {
+	return g.signer.Public(), nil
+}
+
+type cryptoSignerWrapper struct {
+	ctx      context.Context
+	hashFunc crypto.Hash
+	sv       *SignerVerifier
+	errFunc  func(error)
+}
+
+func (c cryptoSignerWrapper) Public() crypto.PublicKey {
+	pk, err := c.sv.PublicKey(options.WithContext(c.ctx))
+	if err != nil && c.errFunc != nil {
+		c.errFunc(err)
+	}
+	return pk
+}
+
+func (c cryptoSignerWrapper) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
+	hashFunc := c.hashFunc
+	if opts != nil {
+		hashFunc = opts.HashFunc()
+	}
+	gcpOptions := []signature.SignOption{
+		options.WithContext(c.ctx),
+		options.WithDigest(digest),
+		options.WithCryptoSignerOpts(hashFunc),
+	}
+
+	return c.sv.SignMessage(nil, gcpOptions...)
+}
+
+// CryptoSigner returns a crypto.Signer object that uses the underlying SignerVerifier, along with a crypto.SignerOpts object
+// that allows the KMS to be used in APIs that only accept the standard golang objects
+func (g *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) (crypto.Signer, crypto.SignerOpts, error) {
+	csw := &cryptoSignerWrapper{
+		ctx:      ctx,
+		sv:       g,
+		hashFunc: crypto.SHA256,
+		errFunc:  errFunc,
+	}
+
+	return csw, crypto.SHA256, nil
+}
+
+// SupportedAlgorithms returns a list with the default algorithm
+func (g *SignerVerifier) SupportedAlgorithms() (result []string) {
+	return []string{"ecdsa-p256-sha256"}
+}
+
+// DefaultAlgorithm returns the default algorithm for the signer
+func (g *SignerVerifier) DefaultAlgorithm() string {
+	return "ecdsa-p256-sha256"
+}

--- a/pkg/signature/kms/fake/signer_test.go
+++ b/pkg/signature/kms/fake/signer_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
+	"testing"
+
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature/kms"
+)
+
+func TestFakeSigner(t *testing.T) {
+	msg := []byte{1, 2, 3, 4, 5}
+
+	signer, err := kms.Get(context.Background(), "fakekms://projects/project/locations/us-west1/keyRings/key-ring/cryptoKeys/key/cryptoKeyVersions/1", crypto.SHA256)
+	if err != nil {
+		t.Fatalf("unexpected error getting signer: %v", err)
+	}
+	pub, err := signer.PublicKey()
+	if err != nil {
+		t.Fatalf("unexpected error getting public key")
+	}
+	createdPub, err := signer.CreateKey(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error creating key: %v", err)
+	}
+	if err := cryptoutils.EqualKeys(createdPub, pub); err != nil {
+		t.Fatalf("expected public keys to be equal: %v", err)
+	}
+
+	if signer.DefaultAlgorithm() != signer.SupportedAlgorithms()[0] {
+		t.Fatal("expected algorithms to match")
+	}
+
+	// Test crypto.Signer implementation
+	cryptoSigner, _, err := signer.CryptoSigner(context.Background(), func(err error) {})
+	if err != nil {
+		t.Fatalf("unexpected error fetching crypto.Signer: %v", err)
+	}
+	if err := cryptoutils.EqualKeys(cryptoSigner.Public(), pub); err != nil {
+		t.Fatalf("expected public keys to be equal: %v", err)
+	}
+
+	sha := sha256.New()
+	sha.Write(msg)
+	digest := sha.Sum(nil)
+	sig, err := cryptoSigner.Sign(rand.Reader, digest, nil)
+	if err != nil {
+		t.Fatalf("unexpected error signing with crypto.Signer: %v", err)
+	}
+	if err := signer.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err != nil {
+		t.Fatalf("unexpected error verifying signature: %v", err)
+	}
+}


### PR DESCRIPTION
This allows us to test code that uses kms.Get by importing the fake KMS
package.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added fake KMS signer for testing
```
