### PR TITLE
fix if check in the release job

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -51,7 +51,7 @@ jobs:
           path: ./src/github.com/sigstore/${{ inputs.repo }}
 
       - name: Set release tag if not specified
-        if: ${{ inputs.release_tag = '' }}
+        if: ${{ inputs.release_tag == '' }}
         run: |
           git fetch --all --tags
           LATEST_DIGEST=`git rev-list --tags --max-count=1`


### PR DESCRIPTION
#### Summary
- fix if check in the release job

```
The workflow is not valid. In .github/workflows/cut-release.yml (Line: 24, Col: 11): Error from called workflow sigstore/sigstore/.github/workflows/reusable-release.yml@main (Line: 54, Col: 13): Unexpected symbol: '='. Located at position 20 within expression: inputs.release_tag = '' sigstore/sigstore/.github/workflows/reusable-release.yml@main (Line: 76, Col: 14): Unexpected symbol: '}'. Located at position 17 within expression: env.RELEASE_TAG },_TOOL_ORG=sigstore,_TOOL_REPO=${{ inputs.repo

````
#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
