### PR TITLE
chore: set redirect URL in doOobFlow

### DIFF
--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -36,7 +36,9 @@ const oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
 type browserOpener func(url string) error
 
 func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOption) string {
-	cfg.RedirectURL = oobRedirectURI
+	if cfg.RedirectURL == "" {
+		cfg.RedirectURL = oobRedirectURI
+	}
 	authURL := cfg.AuthCodeURL(stateToken, opts...)
 	fmt.Fprintln(os.Stderr, "Go to the following link in a browser:\n\n\t", authURL)
 	fmt.Fprintf(os.Stderr, "Enter verification code: ")

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -126,7 +126,9 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 }
 
 func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOption) string {
-	cfg.RedirectURL = oobRedirectURI
+	if cfg.RedirectURL == "" {
+		cfg.RedirectURL = oobRedirectURI
+	}
 	authURL := cfg.AuthCodeURL(stateToken, opts...)
 	fmt.Fprintln(os.Stderr, "Go to the following link in a browser:\n\n\t", authURL)
 	fmt.Fprintf(os.Stderr, "Enter verification code: ")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

I realized the RedirectURL was not reseted to `urn:ietf:wg:oauth:2.0:oob` even if a different value was set.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
