### PR TITLE
run tests with go1.17 and go1.18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,20 +24,24 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  GO_VERSION: 1.18
-
 jobs:
   unit_test:
     name: unit tests
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version:
+          - 1.18.x
+          - 1.17.x
+
     steps:
     - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3
 
     - name: Set up Go
       uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab # v2.2.0
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version: ${{ matrix.go-version }}
     - name: Cache Modules
       uses: actions/cache@136d96b4aee02b1f0de3ba493b1d47135042d9c0 # v2.1.7
       with:


### PR DESCRIPTION

#### Summary
- run tests with go1.17 and go1.18
follow-up https://github.com/sigstore/sigstore/pull/374/files#r845966876

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
