### PR TITLE
Add method for generating certificate serial number

### DIFF
--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -17,11 +17,13 @@ package cryptoutils
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"time"
 )
 
@@ -123,4 +125,17 @@ func ParseCSR(csr []byte) (*x509.CertificateRequest, error) {
 	}
 
 	return x509.ParseCertificateRequest(derBlock.Bytes)
+}
+
+// GenerateSerialNumber creates a compliant serial number as per RFC 5280 4.1.2.2.
+// Serial numbers must be positive, and can be no longer than 20 bytes.
+// The serial number is generated with 159 bits, so that the first bit will always
+// be 0, resulting in a positive serial number.
+func GenerateSerialNumber() (*big.Int, error) {
+	// Pick a random number from 0 to 2^159.
+	serial, err := rand.Int(rand.Reader, (&big.Int{}).Exp(big.NewInt(2), big.NewInt(159), nil))
+	if err != nil {
+		return nil, errors.New("error generating serial number")
+	}
+	return serial, nil
 }

--- a/pkg/cryptoutils/certificate_test.go
+++ b/pkg/cryptoutils/certificate_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"math/big"
 	"strings"
 	"testing"
 	"time"
@@ -362,5 +363,23 @@ func TestParseCSR(t *testing.T) {
 	_, err = ParseCSR(pemCSR)
 	if err == nil || !strings.Contains(err.Error(), "DER type BEGIN CERTIFICATE is not of any type") {
 		t.Fatalf("expected error parsing invalid CSR, got %v", err)
+	}
+}
+
+func TestGenerateSerialNumber(t *testing.T) {
+	serialNumber, err := GenerateSerialNumber()
+	if err != nil {
+		t.Fatalf("unexpected error generating serial number: %v", err)
+	}
+	if serialNumber.Cmp(big.NewInt(0)) == -1 {
+		t.Fatalf("serial number is negative: %v", serialNumber)
+	}
+	if serialNumber.Cmp(big.NewInt(0)) == 0 {
+		t.Fatalf("serial number is 0: %v", serialNumber)
+	}
+	maxSerial := (&big.Int{}).Exp(big.NewInt(2), big.NewInt(159), nil)
+	// Serial number must be less than max serial number.
+	if serialNumber.Cmp(maxSerial) >= 0 {
+		t.Fatalf("serial number is too large: %v", serialNumber)
 	}
 }


### PR DESCRIPTION
This method comes from Fulcio and will be used by Rekor when generating
timestamping authority certificates.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added method to generate RFC 5280 compliant serial numbers
```
