### PR TITLE
Add error type for kms.Get when provider not found

### DIFF
--- a/pkg/signature/kms/kms.go
+++ b/pkg/signature/kms/kms.go
@@ -24,6 +24,14 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
+type ProviderNotFoundError struct {
+	ref string
+}
+
+func (e *ProviderNotFoundError) Error() string {
+	return fmt.Sprintf("no kms provider found for key reference: %s", e.ref)
+}
+
 type providerInit func(context.Context, string, crypto.Hash, ...signature.RPCOption) (SignerVerifier, error)
 
 type providers struct {
@@ -46,7 +54,7 @@ func Get(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts .
 			return providerInit(ctx, keyResourceID, hashFunc, opts...)
 		}
 	}
-	return nil, fmt.Errorf("no provider found for that key reference")
+	return nil, &ProviderNotFoundError{ref: keyResourceID}
 }
 
 // SupportedProviders returns list of initialized providers

--- a/pkg/signature/kms/kms.go
+++ b/pkg/signature/kms/kms.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
+// ProviderNotFoundError indicates that no matching KMS provider was found
 type ProviderNotFoundError struct {
 	ref string
 }
@@ -47,7 +48,9 @@ var providersMux = &providers{
 	providers: map[string]providerInit{},
 }
 
-// Get returns a KMS SignerVerifier for the given resource string and hash function
+// Get returns a KMS SignerVerifier for the given resource string and hash function.
+// If no matching provider is found, Get returns a ProviderNotFoundError. It
+// also returns an error if initializing the SignerVerifier fails.
 func Get(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts ...signature.RPCOption) (SignerVerifier, error) {
 	for ref, providerInit := range providersMux.providers {
 		if strings.HasPrefix(keyResourceID, ref) {


### PR DESCRIPTION
#### Summary
Add error type for kms.Get when provider not found
#### Ticket Link
N/A but helpful for [cosign#1776](https://github.com/sigstore/cosign/issues/1776)
#### Release Note
```release-note
NONE
```
