### PR TITLE
Call ValidReference in all KMS cases

### DIFF
--- a/pkg/signature/kms/aws/client.go
+++ b/pkg/signature/kms/aws/client.go
@@ -107,22 +107,25 @@ func parseReference(resourceID string) (endpoint, keyID, alias string, err error
 	return
 }
 
-func newAWSClient(keyResourceID string) (a *awsClient, err error) {
-	a = &awsClient{}
+func newAWSClient(keyResourceID string) (*awsClient, error) {
+	if err := ValidReference(keyResourceID); err != nil {
+		return nil, err
+	}
+	a := &awsClient{}
+	var err error
 	a.endpoint, a.keyID, a.alias, err = parseReference(keyResourceID)
 	if err != nil {
 		return nil, err
 	}
 
-	err = a.setupClient()
-	if err != nil {
+	if err := a.setupClient(); err != nil {
 		return nil, err
 	}
 
 	a.keyCache = ttlcache.NewCache()
 	a.keyCache.SetLoaderFunction(a.keyCacheLoaderFunction)
 	a.keyCache.SkipTTLExtensionOnHit(true)
-	return
+	return a, nil
 }
 
 func (a *awsClient) setupClient() (err error) {

--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -86,6 +86,9 @@ func parseReference(resourceID string) (vaultURL, vaultName, keyName string, err
 }
 
 func newAzureKMS(_ context.Context, keyResourceID string) (*azureVaultClient, error) {
+	if err := ValidReference(keyResourceID); err != nil {
+		return nil, err
+	}
 	vaultURL, vaultName, keyName, err := parseReference(keyResourceID)
 	if err != nil {
 		return nil, err

--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -85,8 +85,7 @@ type gcpClient struct {
 }
 
 func newGCPClient(ctx context.Context, refStr string) (*gcpClient, error) {
-	var err error
-	if err = ValidReference(refStr); err != nil {
+	if err := ValidReference(refStr); err != nil {
 		return nil, err
 	}
 
@@ -99,6 +98,7 @@ func newGCPClient(ctx context.Context, refStr string) (*gcpClient, error) {
 		refString:  refStr,
 		kvCache:    ttlcache.NewCache(),
 	}
+	var err error
 	g.projectID, g.locationID, g.keyRing, g.keyName, g.version, err = parseReference(refStr)
 	if err != nil {
 		return nil, err

--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -87,6 +87,10 @@ func parseReference(resourceID string) (keyPath string, err error) {
 }
 
 func newHashivaultClient(address, token, transitSecretEnginePath, keyResourceID string, keyVersion uint64) (*hashivaultClient, error) {
+	if err := ValidReference(keyResourceID); err != nil {
+		return nil, err
+	}
+
 	keyPath, err := parseReference(keyResourceID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
These methods were defined in all the KMS impls, but were only actually
called in the GCP case. It's possible they were used outside this
pacekage, since they're exported, but for consistency we should ensure
the reference is valid before proceeding to make API calls.

Signed-off-by: Jason Hall <jason@chainguard.dev>

```release-note
KMS implementations all ensure the reference is valid before proceeding.
```
