### PR TITLE
Add method to unmarshal certificates with a limit

### DIFF
--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -76,6 +76,35 @@ func UnmarshalCertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) 
 	return result, nil
 }
 
+// UnmarshalCertificatesFromPEMLimited extracts one or more X509 certificates from the provided
+// byte slice, which is assumed to be in PEM-encoded format. Fails after a specified
+// number of iterations.
+func UnmarshalCertificatesFromPEMLimited(pemBytes []byte, iterations int) ([]*x509.Certificate, error) {
+	result := []*x509.Certificate{}
+	remaining := pemBytes
+
+	count := 0
+	for len(remaining) > 0 {
+		if count == iterations {
+			return nil, errors.New("too many certificates specified in PEM block")
+		}
+		var certDer *pem.Block
+		certDer, remaining = pem.Decode(remaining)
+
+		if certDer == nil {
+			return nil, errors.New("error during PEM decoding")
+		}
+
+		cert, err := x509.ParseCertificate(certDer.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, cert)
+		count++
+	}
+	return result, nil
+}
+
 // LoadCertificatesFromPEM extracts one or more X509 certificates from the provided
 // io.Reader.
 func LoadCertificatesFromPEM(pem io.Reader) ([]*x509.Certificate, error) {

--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -78,7 +78,7 @@ func UnmarshalCertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) 
 
 // UnmarshalCertificatesFromPEMLimited extracts one or more X509 certificates from the provided
 // byte slice, which is assumed to be in PEM-encoded format. Fails after a specified
-// number of iterations.
+// number of iterations. A reasonable limit is 10 iterations.
 func UnmarshalCertificatesFromPEMLimited(pemBytes []byte, iterations int) ([]*x509.Certificate, error) {
 	result := []*x509.Certificate{}
 	remaining := pemBytes


### PR DESCRIPTION
This removes a DOS vector for services that use this method. Otherwise,
a client can provide a large PEM block to cause the service to do a
significant amount of work.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added method to unmarshal certificates from a PEM block with a limit
```
