### PR TITLE
Add unsafe verifier to verify signatures with SHA1 digests

### DIFF
--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -26,7 +26,16 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
+// checked on LoadSigner, LoadVerifier and SignMessage
 var ecdsaSupportedHashFuncs = []crypto.Hash{
+	crypto.SHA256,
+	crypto.SHA512,
+	crypto.SHA384,
+	crypto.SHA224,
+}
+
+// checked on VerifySignature. Supports SHA1 verification.
+var ecdsaSupportedVerifyHashFuncs = []crypto.Hash{
 	crypto.SHA256,
 	crypto.SHA512,
 	crypto.SHA384,
@@ -128,6 +137,10 @@ func LoadECDSAVerifier(pub *ecdsa.PublicKey, hashFunc crypto.Hash) (*ECDSAVerifi
 		return nil, errors.New("invalid ECDSA public key specified")
 	}
 
+	if !isSupportedAlg(hashFunc, ecdsaSupportedHashFuncs) {
+		return nil, errors.New("invalid hash function specified")
+	}
+
 	return &ECDSAVerifier{
 		publicKey: pub,
 		hashFunc:  hashFunc,
@@ -153,7 +166,7 @@ func (e ECDSAVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error)
 //
 // All other options are ignored if specified.
 func (e ECDSAVerifier) VerifySignature(signature, message io.Reader, opts ...VerifyOption) error {
-	digest, _, err := ComputeDigestForVerifying(message, e.hashFunc, ecdsaSupportedHashFuncs, opts...)
+	digest, _, err := ComputeDigestForVerifying(message, e.hashFunc, ecdsaSupportedVerifyHashFuncs, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/signature/rsapkcs1v15.go
+++ b/pkg/signature/rsapkcs1v15.go
@@ -153,7 +153,7 @@ func (r RSAPKCS1v15Verifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, 
 //
 // All other options are ignored if specified.
 func (r RSAPKCS1v15Verifier) VerifySignature(signature, message io.Reader, opts ...VerifyOption) error {
-	digest, hf, err := ComputeDigestForVerifying(message, r.hashFunc, rsaSupportedHashFuncs, opts...)
+	digest, hf, err := ComputeDigestForVerifying(message, r.hashFunc, rsaSupportedVerifyHashFuncs, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/signature/rsapss.go
+++ b/pkg/signature/rsapss.go
@@ -25,7 +25,16 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
+// checked on LoadSigner, LoadVerifier, and SignMessage
 var rsaSupportedHashFuncs = []crypto.Hash{
+	crypto.SHA256,
+	crypto.SHA384,
+	crypto.SHA512,
+}
+
+// checked on VerifySignature. Supports SHA1 verification.
+var rsaSupportedVerifyHashFuncs = []crypto.Hash{
+	crypto.SHA1,
 	crypto.SHA256,
 	crypto.SHA384,
 	crypto.SHA512,
@@ -171,7 +180,7 @@ func (r RSAPSSVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error
 //
 // All other options are ignored if specified.
 func (r RSAPSSVerifier) VerifySignature(signature, message io.Reader, opts ...VerifyOption) error {
-	digest, hf, err := ComputeDigestForVerifying(message, r.hashFunc, rsaSupportedHashFuncs, opts...)
+	digest, hf, err := ComputeDigestForVerifying(message, r.hashFunc, rsaSupportedVerifyHashFuncs, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -51,6 +51,35 @@ func LoadVerifier(publicKey crypto.PublicKey, hashFunc crypto.Hash) (Verifier, e
 	return nil, errors.New("unsupported public key type")
 }
 
+// LoadUnsafeVerifier returns a signature.Verifier based on the algorithm of the public key
+// provided that will use SHA1 when computing digests for RSA and ECDSA signatures.
+//
+// If publicKey is an RSA key, a RSAPKCS1v15Verifier will be returned. If a
+// RSAPSSVerifier is desired instead, use the LoadRSAPSSVerifier() method directly.
+func LoadUnsafeVerifier(publicKey crypto.PublicKey) (Verifier, error) {
+	switch pk := publicKey.(type) {
+	case *rsa.PublicKey:
+		if pk == nil {
+			return nil, errors.New("invalid RSA public key specified")
+		}
+		return &RSAPKCS1v15Verifier{
+			publicKey: pk,
+			hashFunc:  crypto.SHA1,
+		}, nil
+	case *ecdsa.PublicKey:
+		if pk == nil {
+			return nil, errors.New("invalid ECDSA public key specified")
+		}
+		return &ECDSAVerifier{
+			publicKey: pk,
+			hashFunc:  crypto.SHA1,
+		}, nil
+	case ed25519.PublicKey:
+		return LoadED25519Verifier(pk)
+	}
+	return nil, errors.New("unsupported public key type")
+}
+
 // LoadVerifierFromPEMFile returns a signature.Verifier based on the contents of a
 // file located at path. The Verifier wil use the hash function specified when computing digests.
 //

--- a/pkg/signature/verifier_test.go
+++ b/pkg/signature/verifier_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signature
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+)
+
+func TestLoadUnsafeVerifier(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("unexpected error generating key: %v", err)
+	}
+	verifier, err := LoadUnsafeVerifier(key.Public())
+	if err != nil {
+		t.Fatalf("unexpected error loading verifier: %v", err)
+	}
+	pubKey, _ := verifier.PublicKey()
+	if !key.PublicKey.Equal(pubKey) {
+		t.Fatalf("public keys were not equal")
+	}
+}


### PR DESCRIPTION
I relaxed the hash function constraints on VerifyMessage, including the
SHA1 digest as a supported function. The expectation is that
LoadVerifier will still be the primary way to set up a verifier, which
will enforce the hash function. Otherwise, LoadUnsafeVerifier will be
used to load a verifier that only supports SHA1.

Note that SignMessage will not support SHA1 still.

I also dropped SHA1 from ECDSA's supported hash functions.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added support for an unsafe verifier to verify signatures that use SHA1. Only use if SHA1 is required.
```
