### PR TITLE
Remove dependency on deprecated github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/letsencrypt/boulder v0.0.0-20220331220046-b23ab962616e
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
-	github.com/pkg/errors v0.9.1
 	github.com/secure-systems-lab/go-securesystemslib v0.3.1
 	github.com/segmentio/ksuid v1.0.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966

--- a/go.sum
+++ b/go.sum
@@ -918,7 +918,6 @@ github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzL
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -16,6 +16,7 @@ package oidc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 
 	coreoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/pkg/browser"
-	"github.com/pkg/errors"
 	"github.com/segmentio/ksuid"
 	"github.com/sigstore/sigstore/pkg/oauth"
 	"golang.org/x/oauth2"
@@ -145,7 +145,7 @@ func (idts *interactiveIDTokenSource) IDToken(ctx context.Context) (*IDToken, er
 	if err != nil {
 		close(codeCh)
 		close(errCh)
-		return nil, errors.Wrap(err, "starting redirect listener")
+		return nil, fmt.Errorf("starting redirect listener: %w", err)
 	}
 	defer func() {
 		go func() {

--- a/pkg/oauth/oidc/interactive_e2e_test.go
+++ b/pkg/oauth/oidc/interactive_e2e_test.go
@@ -19,12 +19,12 @@ package oidc
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 
 	coreoidc "github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-rod/rod"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/oauth2"

--- a/pkg/oauth/oidc/token.go
+++ b/pkg/oauth/oidc/token.go
@@ -16,9 +16,9 @@ package oidc
 
 import (
 	"context"
+	"errors"
 
 	coreoidc "github.com/coreos/go-oidc/v3/oidc"
-	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
 

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -17,6 +17,7 @@ package oauthflow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -25,7 +26,6 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
-	"github.com/pkg/errors"
 	"github.com/segmentio/ksuid"
 	"github.com/skratchdot/open-golang/open"
 	"golang.org/x/oauth2"
@@ -53,7 +53,7 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 	// starts listener using the redirect_uri, otherwise starts on ephemeral port
 	redirectServer, redirectURL, err := startRedirectListener(stateToken, i.HTMLPage, cfg.RedirectURL, doneCh, errCh)
 	if err != nil {
-		return nil, errors.Wrap(err, "starting redirect listener")
+		return nil, fmt.Errorf("starting redirect listener: %w", err)
 	}
 	defer func() {
 		go func() {

--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -20,9 +20,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"errors"
+	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
@@ -177,11 +178,11 @@ func (e ECDSAVerifier) VerifySignature(signature, message io.Reader, opts ...Ver
 
 	sigBytes, err := io.ReadAll(signature)
 	if err != nil {
-		return errors.Wrap(err, "reading signature")
+		return fmt.Errorf("reading signature: %w", err)
 	}
 
 	if !ecdsa.VerifyASN1(e.publicKey, digest, sigBytes) {
-		return errors.New("failed to verify signature")
+		return fmt.Errorf("failed to verify signature: %w", err)
 	}
 	return nil
 }
@@ -197,11 +198,11 @@ type ECDSASignerVerifier struct {
 func LoadECDSASignerVerifier(priv *ecdsa.PrivateKey, hf crypto.Hash) (*ECDSASignerVerifier, error) {
 	signer, err := LoadECDSASigner(priv, hf)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing signer")
+		return nil, fmt.Errorf("initializing signer: %w", err)
 	}
 	verifier, err := LoadECDSAVerifier(&priv.PublicKey, hf)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing verifier")
+		return nil, fmt.Errorf("initializing verifier: %w", err)
 	}
 
 	return &ECDSASignerVerifier{

--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -20,9 +20,9 @@ import (
 	"crypto"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
+	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 var ed25519SupportedHashFuncs = []crypto.Hash{
@@ -130,7 +130,7 @@ func (e *ED25519Verifier) VerifySignature(signature, message io.Reader, _ ...Ver
 
 	sigBytes, err := io.ReadAll(signature)
 	if err != nil {
-		return errors.Wrap(err, "reading signature")
+		return fmt.Errorf("reading signature: %w", err)
 	}
 
 	if !ed25519.Verify(e.publicKey, messageBytes, sigBytes) {
@@ -150,12 +150,12 @@ type ED25519SignerVerifier struct {
 func LoadED25519SignerVerifier(priv ed25519.PrivateKey) (*ED25519SignerVerifier, error) {
 	signer, err := LoadED25519Signer(priv)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing signer")
+		return nil, fmt.Errorf("initializing signer: %w", err)
 	}
 	pub := priv.Public().(ed25519.PublicKey)
 	verifier, err := LoadED25519Verifier(pub)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing verifier")
+		return nil, fmt.Errorf("initializing verifier: %w", err)
 	}
 
 	return &ED25519SignerVerifier{

--- a/pkg/signature/kms/aws/client.go
+++ b/pkg/signature/kms/aws/client.go
@@ -22,6 +22,7 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -33,7 +34,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
 )
@@ -103,7 +103,7 @@ func parseReference(resourceID string) (endpoint, keyID, alias string, err error
 			return
 		}
 	}
-	err = errors.Errorf("invalid awskms format %q", resourceID)
+	err = fmt.Errorf("invalid awskms format %q", resourceID)
 	return
 }
 
@@ -141,7 +141,7 @@ func (a *awsClient) setupClient() (err error) {
 	}
 	sess, err = session.NewSession(config)
 	if err != nil {
-		return errors.Wrap(err, "new aws session")
+		return fmt.Errorf("new aws session: %w", err)
 	}
 	a.client = kms.New(sess)
 	return
@@ -235,7 +235,7 @@ func (a *awsClient) createKey(ctx context.Context, algorithm string) (crypto.Pub
 	// return error if not *kms.NotFoundException
 	var errNotFound *kms.NotFoundException
 	if !errors.As(err, &errNotFound) {
-		return nil, errors.Wrap(err, "looking up key")
+		return nil, fmt.Errorf("looking up key: %w", err)
 	}
 
 	usage := kms.KeyUsageTypeSignVerify
@@ -246,7 +246,7 @@ func (a *awsClient) createKey(ctx context.Context, algorithm string) (crypto.Pub
 		Description:           &description,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "creating key")
+		return nil, fmt.Errorf("creating key: %w", err)
 	}
 
 	_, err = a.client.CreateAliasWithContext(ctx, &kms.CreateAliasInput{
@@ -254,7 +254,7 @@ func (a *awsClient) createKey(ctx context.Context, algorithm string) (crypto.Pub
 		TargetKeyId: key.KeyMetadata.KeyId,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating alias %q", a.alias)
+		return nil, fmt.Errorf("creating alias %q: %w", a.alias, err)
 	}
 
 	return a.public(ctx)
@@ -286,7 +286,7 @@ func (a *awsClient) verifyRemotely(ctx context.Context, sig []byte, digest []byt
 		Signature:        sig,
 		SigningAlgorithm: alg,
 	})
-	return errors.Wrap(err, "unable to verify signature")
+	return fmt.Errorf("unable to verify signature: %w", err)
 }
 
 func (a *awsClient) public(ctx context.Context) (crypto.PublicKey, error) {
@@ -312,7 +312,7 @@ func (a *awsClient) sign(ctx context.Context, digest []byte, _ crypto.Hash) ([]b
 		SigningAlgorithm: alg,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "signing with kms")
+		return nil, fmt.Errorf("signing with kms: %w", err)
 	}
 	return out.Signature, nil
 }
@@ -322,11 +322,11 @@ func (a *awsClient) fetchPublicKey(ctx context.Context) (crypto.PublicKey, error
 		KeyId: &a.keyID,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "getting public key")
+		return nil, fmt.Errorf("getting public key: %w", err)
 	}
 	key, err := x509.ParsePKIXPublicKey(out.PublicKey)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing public key")
+		return nil, fmt.Errorf("parsing public key: %w", err)
 	}
 	return key, nil
 }
@@ -336,7 +336,7 @@ func (a *awsClient) fetchKeyMetadata(ctx context.Context) (*kms.KeyMetadata, err
 		KeyId: &a.keyID,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "getting key metadata")
+		return nil, fmt.Errorf("getting key metadata: %w", err)
 	}
 	return out.KeyMetadata, nil
 }

--- a/pkg/signature/kms/aws/signer.go
+++ b/pkg/signature/kms/aws/signer.go
@@ -18,10 +18,10 @@ package aws
 import (
 	"context"
 	"crypto"
+	"fmt"
 	"io"
 
 	"github.com/aws/aws-sdk-go/service/kms"
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
@@ -87,7 +87,7 @@ func (a *SignerVerifier) SignMessage(message io.Reader, opts ...signature.SignOp
 	var signerOpts crypto.SignerOpts
 	signerOpts, err = a.client.getHashFunc(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting fetching default hash function")
+		return nil, fmt.Errorf("getting fetching default hash function: %w", err)
 	}
 	for _, opt := range opts {
 		opt.ApplyCryptoSignerOpts(&signerOpts)
@@ -154,7 +154,7 @@ func (a *SignerVerifier) VerifySignature(sig, message io.Reader, opts ...signatu
 	var signerOpts crypto.SignerOpts
 	signerOpts, err = a.client.getHashFunc(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting hash func")
+		return fmt.Errorf("getting hash func: %w", err)
 	}
 	for _, opt := range opts {
 		opt.ApplyCryptoSignerOpts(&signerOpts)
@@ -170,7 +170,7 @@ func (a *SignerVerifier) VerifySignature(sig, message io.Reader, opts ...signatu
 
 	sigBytes, err := io.ReadAll(sig)
 	if err != nil {
-		return errors.Wrap(err, "reading signature")
+		return fmt.Errorf("reading signature: %w", err)
 	}
 	return a.client.verifyRemotely(ctx, sigBytes, digest)
 }
@@ -214,7 +214,7 @@ func (c cryptoSignerWrapper) Sign(_ io.Reader, digest []byte, opts crypto.Signer
 func (a *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) (crypto.Signer, crypto.SignerOpts, error) {
 	defaultHf, err := a.client.getHashFunc(ctx)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "getting fetching default hash function")
+		return nil, nil, fmt.Errorf("getting fetching default hash function: %w", err)
 	}
 
 	csw := &cryptoSignerWrapper{

--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -21,6 +21,7 @@ import (
 	"crypto/ecdsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -28,7 +29,6 @@ import (
 	"time"
 
 	"github.com/ReneKroon/ttlcache/v2"
-	"github.com/pkg/errors"
 	jose "gopkg.in/square/go-jose.v2"
 
 	kvauth "github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
@@ -76,7 +76,7 @@ func ValidReference(ref string) error {
 func parseReference(resourceID string) (vaultURL, vaultName, keyName string, err error) {
 	v := referenceRegex.FindStringSubmatch(resourceID)
 	if len(v) != 3 {
-		err = errors.Errorf("invalid azurekms format %q", resourceID)
+		err = fmt.Errorf("invalid azurekms format %q", resourceID)
 		return
 	}
 
@@ -96,7 +96,7 @@ func newAzureKMS(_ context.Context, keyResourceID string) (*azureVaultClient, er
 
 	client, err := getKeysClient()
 	if err != nil {
-		return nil, errors.Wrap(err, "new azure kms client")
+		return nil, fmt.Errorf("new azure kms client: %w", err)
 	}
 
 	azClient := &azureVaultClient{
@@ -211,18 +211,18 @@ func (a *azureVaultClient) keyCacheLoaderFunction(key string) (data interface{},
 func (a *azureVaultClient) fetchPublicKey(ctx context.Context) (crypto.PublicKey, error) {
 	key, err := a.getKey(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "public key")
+		return nil, fmt.Errorf("public key: %w", err)
 	}
 
 	jwkJSON, err := json.Marshal(*key.Key)
 	if err != nil {
-		return nil, errors.Wrap(err, "encoding the jsonWebKey")
+		return nil, fmt.Errorf("encoding the jsonWebKey: %w", err)
 	}
 
 	jwk := jose.JSONWebKey{}
 	err = jwk.UnmarshalJSON(jwkJSON)
 	if err != nil {
-		return nil, errors.Wrap(err, "decoding the jsonWebKey")
+		return nil, fmt.Errorf("decoding the jsonWebKey: %w", err)
 	}
 
 	pub, ok := jwk.Key.(*ecdsa.PublicKey)
@@ -238,7 +238,7 @@ func (a *azureVaultClient) fetchPublicKey(ctx context.Context) (crypto.PublicKey
 func (a *azureVaultClient) getKey(ctx context.Context) (keyvault.KeyBundle, error) {
 	key, err := a.client.GetKey(ctx, a.vaultURL, a.keyName, "")
 	if err != nil {
-		return keyvault.KeyBundle{}, errors.Wrap(err, "public key")
+		return keyvault.KeyBundle{}, fmt.Errorf("public key: %w", err)
 	}
 
 	return key, err
@@ -287,12 +287,12 @@ func (a *azureVaultClient) sign(ctx context.Context, hash []byte) ([]byte, error
 
 	result, err := a.client.Sign(ctx, a.vaultURL, a.keyName, "", params)
 	if err != nil {
-		return nil, errors.Wrap(err, "signing the payload")
+		return nil, fmt.Errorf("signing the payload: %w", err)
 	}
 
 	decResult, err := base64.RawURLEncoding.DecodeString(*result.Result)
 	if err != nil {
-		return nil, errors.Wrap(err, "decoding the result")
+		return nil, fmt.Errorf("decoding the result: %w", err)
 	}
 
 	return decResult, nil
@@ -307,7 +307,7 @@ func (a *azureVaultClient) verify(ctx context.Context, signature, hash []byte) e
 
 	result, err := a.client.Verify(ctx, a.vaultURL, a.keyName, "", params)
 	if err != nil {
-		return errors.Wrap(err, "verify")
+		return fmt.Errorf("verify: %w", err)
 	}
 
 	if !*result.Value {

--- a/pkg/signature/kms/azure/signer.go
+++ b/pkg/signature/kms/azure/signer.go
@@ -18,10 +18,11 @@ package azure
 import (
 	"context"
 	"crypto"
+	"errors"
+	"fmt"
 	"io"
 	"math/big"
 
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
 
@@ -148,7 +149,7 @@ func (a *SignerVerifier) VerifySignature(sig, message io.Reader, opts ...signatu
 
 	sigBytes, err := io.ReadAll(sig)
 	if err != nil {
-		return errors.Wrap(err, "reading signature")
+		return fmt.Errorf("reading signature: %w", err)
 	}
 
 	// Convert the ANS.1 Sequence to a concantenated r||s byte string

--- a/pkg/signature/kms/gcp/signer.go
+++ b/pkg/signature/kms/gcp/signer.go
@@ -18,10 +18,10 @@ package gcp
 import (
 	"context"
 	"crypto"
+	"fmt"
 	"hash/crc32"
 	"io"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
@@ -76,7 +76,7 @@ func (g *SignerVerifier) SignMessage(message io.Reader, opts ...signature.SignOp
 
 	signerOpts, err = g.client.getHashFunc()
 	if err != nil {
-		return nil, errors.Wrap(err, "getting fetching default hash function")
+		return nil, fmt.Errorf("getting fetching default hash function: %w", err)
 	}
 
 	for _, opt := range opts {
@@ -167,7 +167,7 @@ func (c cryptoSignerWrapper) Sign(_ io.Reader, digest []byte, opts crypto.Signer
 func (g *SignerVerifier) CryptoSigner(ctx context.Context, errFunc func(error)) (crypto.Signer, crypto.SignerOpts, error) {
 	defaultHf, err := g.client.getHashFunc()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "getting fetching default hash function")
+		return nil, nil, fmt.Errorf("getting fetching default hash function: %w", err)
 	}
 
 	csw := &cryptoSignerWrapper{

--- a/pkg/signature/kms/hashivault/signer.go
+++ b/pkg/signature/kms/hashivault/signer.go
@@ -18,10 +18,11 @@ package hashivault
 import (
 	"context"
 	"crypto"
+	"errors"
+	"fmt"
 	"io"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
@@ -82,7 +83,7 @@ func LoadSignerVerifier(referenceStr string, hashFunc crypto.Hash, opts ...signa
 	if keyVersion != "" {
 		keyVersionUint, err = strconv.ParseUint(keyVersion, 10, 64)
 		if err != nil {
-			return nil, errors.Wrap(err, "parsing key version")
+			return nil, fmt.Errorf("parsing key version: %w", err)
 		}
 	}
 
@@ -168,7 +169,7 @@ func (h SignerVerifier) VerifySignature(sig, message io.Reader, opts ...signatur
 
 	sigBytes, err := io.ReadAll(sig)
 	if err != nil {
-		return errors.Wrap(err, "reading signature")
+		return fmt.Errorf("reading signature: %w", err)
 	}
 
 	return h.client.verify(sigBytes, digest, hf, opts...)

--- a/pkg/signature/message.go
+++ b/pkg/signature/message.go
@@ -18,10 +18,9 @@ package signature
 import (
 	"crypto"
 	crand "crypto/rand"
+	"errors"
 	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 func isSupportedAlg(alg crypto.Hash, supportedAlgs []crypto.Hash) bool {
@@ -98,7 +97,7 @@ func hashMessage(rawMessage io.Reader, hashFunc crypto.Hash) ([]byte, error) {
 	hasher := hashFunc.New()
 	// avoids reading entire message into memory
 	if _, err := io.Copy(hasher, rawMessage); err != nil {
-		return nil, errors.Wrap(err, "hashing message")
+		return nil, fmt.Errorf("hashing message: %w", err)
 	}
 	return hasher.Sum(nil), nil
 }

--- a/pkg/signature/rsapkcs1v15.go
+++ b/pkg/signature/rsapkcs1v15.go
@@ -19,9 +19,10 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
+	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
@@ -164,7 +165,7 @@ func (r RSAPKCS1v15Verifier) VerifySignature(signature, message io.Reader, opts 
 
 	sigBytes, err := io.ReadAll(signature)
 	if err != nil {
-		return errors.Wrap(err, "reading signature")
+		return fmt.Errorf("reading signature: %w", err)
 	}
 
 	return rsa.VerifyPKCS1v15(r.publicKey, hf, digest, sigBytes)
@@ -181,11 +182,11 @@ type RSAPKCS1v15SignerVerifier struct {
 func LoadRSAPKCS1v15SignerVerifier(priv *rsa.PrivateKey, hf crypto.Hash) (*RSAPKCS1v15SignerVerifier, error) {
 	signer, err := LoadRSAPKCS1v15Signer(priv, hf)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing signer")
+		return nil, fmt.Errorf("initializing signer: %w", err)
 	}
 	verifier, err := LoadRSAPKCS1v15Verifier(&priv.PublicKey, hf)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing verifier")
+		return nil, fmt.Errorf("initializing verifier: %w", err)
 	}
 
 	return &RSAPKCS1v15SignerVerifier{

--- a/pkg/signature/rsapss.go
+++ b/pkg/signature/rsapss.go
@@ -19,9 +19,10 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
+	"errors"
+	"fmt"
 	"io"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
@@ -191,7 +192,7 @@ func (r RSAPSSVerifier) VerifySignature(signature, message io.Reader, opts ...Ve
 
 	sigBytes, err := io.ReadAll(signature)
 	if err != nil {
-		return errors.Wrap(err, "reading signature")
+		return fmt.Errorf("reading signature: %w", err)
 	}
 
 	// rsa.VerifyPSS ignores pssOpts.Hash, so we don't set it
@@ -216,11 +217,11 @@ type RSAPSSSignerVerifier struct {
 func LoadRSAPSSSignerVerifier(priv *rsa.PrivateKey, hf crypto.Hash, opts *rsa.PSSOptions) (*RSAPSSSignerVerifier, error) {
 	signer, err := LoadRSAPSSSigner(priv, hf, opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing signer")
+		return nil, fmt.Errorf("initializing signer: %w", err)
 	}
 	verifier, err := LoadRSAPSSVerifier(&priv.PublicKey, hf, opts)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing verifier")
+		return nil, fmt.Errorf("initializing verifier: %w", err)
 	}
 
 	return &RSAPSSSignerVerifier{

--- a/pkg/signature/signer.go
+++ b/pkg/signature/signer.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"errors"
 	"io"
 	"io/ioutil"
 	"path/filepath"
@@ -28,7 +29,6 @@ import (
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 
 	// these ensure we have the implementations loaded

--- a/pkg/signature/signerverifier.go
+++ b/pkg/signature/signerverifier.go
@@ -20,10 +20,10 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -20,11 +20,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
+	"errors"
 	"io"
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 


### PR DESCRIPTION
github.com/pkg/errors is deprecated, archived, and in maintenance mode. Replace `errors.Wrap*` with `fmt.Errorf` and `%w` to wrap errors.

Ref https://github.com/sigstore/cosign/issues/1880

Signed-off-by: Jason Hall <jason@chainguard.dev>

```release-note
Errors are wrapped using Go error wrapping, instead of using github.com/pkg/errors
```
