### PR TITLE
Allow passing options to GCP's `LoadSignVerifier`.

### DIFF
--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	gcpkms "cloud.google.com/go/kms/apiv1"
+	"google.golang.org/api/option"
 	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -84,7 +85,7 @@ type gcpClient struct {
 	kmsClient  *gcpkms.KeyManagementClient
 }
 
-func newGCPClient(ctx context.Context, refStr string) (*gcpClient, error) {
+func newGCPClient(ctx context.Context, refStr string, opts ...option.ClientOption) (*gcpClient, error) {
 	if err := ValidReference(refStr); err != nil {
 		return nil, err
 	}
@@ -104,7 +105,7 @@ func newGCPClient(ctx context.Context, refStr string) (*gcpClient, error) {
 		return nil, err
 	}
 
-	g.kmsClient, err = gcpkms.NewKeyManagementClient(ctx)
+	g.kmsClient, err = gcpkms.NewKeyManagementClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("new gcp kms client: %w", err)
 	}

--- a/pkg/signature/kms/gcp/gcp_test.go
+++ b/pkg/signature/kms/gcp/gcp_test.go
@@ -15,7 +15,13 @@
 
 package gcp
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+)
 
 func TestParseReference(t *testing.T) {
 	tests := []struct {
@@ -94,4 +100,11 @@ func TestParseReference(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOptionsWork(t *testing.T) {
+	// Check that we can pass options into LoadSignerVerifier
+	// (this is mostly a compile-time check)
+	ts := oauth2.StaticTokenSource(&oauth2.Token{})
+	LoadSignerVerifier(context.Background(), "gcpkms://projects/a-project/locations/global/keyRings/a-keyring/cryptoKeys/key-name", option.WithTokenSource(ts))
 }

--- a/pkg/signature/kms/gcp/signer.go
+++ b/pkg/signature/kms/gcp/signer.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
+	"google.golang.org/api/option"
 )
 
 var gcpSupportedHashFuncs = []crypto.Hash{
@@ -41,13 +42,13 @@ type SignerVerifier struct {
 // LoadSignerVerifier generates signatures using the specified key object in GCP KMS and hash algorithm.
 //
 // It also can verify signatures locally using the public key. hashFunc must not be crypto.Hash(0).
-func LoadSignerVerifier(defaultCtx context.Context, referenceStr string) (*SignerVerifier, error) {
+func LoadSignerVerifier(defaultCtx context.Context, referenceStr string, opts ...option.ClientOption) (*SignerVerifier, error) {
 	g := &SignerVerifier{
 		defaultCtx: defaultCtx,
 	}
 
 	var err error
-	g.client, err = newGCPClient(defaultCtx, referenceStr)
+	g.client, err = newGCPClient(defaultCtx, referenceStr, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This lets the caller control authentication, in particular by providing an `option.TokenSource`.

#### Release Note
```release-note
gcp.LoadSignerVerifier can now be passed GRPC ClientOptions
```

cc @imjasonh @dlorenc 