### PR TITLE
Autoclose OAuth success page after 5 seconds.

### DIFF
--- a/pkg/oauth/interactive.go
+++ b/pkg/oauth/interactive.go
@@ -20,7 +20,12 @@ const (
 <title>Sigstore Auth</title>
 <body>
 <h1>Sigstore Auth Successful</h1>
-<p>You may now close this page.</p>
+<p>You may now close this page. This page will automatically close in 5 seconds.</p>
+<script>
+  setTimeout(function() {
+      window.close()
+  }, 5000);
+</script>
 </body>
 </html>
 `


### PR DESCRIPTION

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Small QoL improvement to clean up success pages after they are no longer
needed.

Shout out to @bobcallaway for the idea!

Co-authored-by: Bob Callaway <bcallaway@google.com>
Signed-off-by: Billy Lynch <billy@chainguard.dev>


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Part of #426 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Interactive OAuth success page will now autoclose after 5 seconds.
```
