### PR TITLE
tuf: add a method to retrieve rekor public keys

### DIFF
--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -55,6 +55,19 @@ func UnmarshalPEMToPublicKey(pemBytes []byte) (crypto.PublicKey, error) {
 	return x509.ParsePKIXPublicKey(derBytes.Bytes)
 }
 
+// UnmarshalPEMToECDSAKey converts a PEM-encoded byte slice into an *ecdsa.PublicKey.
+func UnmarshalPEMToECDSAKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
+	pub, err := UnmarshalPEMToPublicKey(pemBytes)
+	if err != nil {
+		return nil, err
+	}
+	ecdsaPub, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("invalid public key: was %T, require *ecdsa.PublicKey", pub)
+	}
+	return ecdsaPub, nil
+}
+
 // MarshalPublicKeyToDER converts a crypto.PublicKey into a PKIX, ASN.1 DER byte slice
 func MarshalPublicKeyToDER(pub crypto.PublicKey) ([]byte, error) {
 	if pub == nil {

--- a/pkg/rekorpubs/rekorpubs.go
+++ b/pkg/rekorpubs/rekorpubs.go
@@ -1,0 +1,89 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rekorpubs
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"sync"
+
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/tuf"
+)
+
+// This is the rekor public key target name
+var rekorTargetStr = `rekor.pub`
+
+// RekorPubKey contains the ECDSA verification key and the current status
+// of the key according to TUF metadata, whether it's active or expired.
+type RekorPubKey struct {
+	PubKey *ecdsa.PublicKey
+	Status tuf.StatusKind
+}
+
+var (
+	rekorOnce         = new(sync.Once)
+	rekorPubKeys      map[string]RekorPubKey
+	singletonRekorErr error
+)
+
+// GetLogID generates a SHA256 hash of a DER-encoded public key.
+func GetLogID(pub crypto.PublicKey) (string, error) {
+	pubBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(pubBytes)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// GetRekorPubs returns a map of rekor public keys keyed by rekor log ID. Each key contains
+// the ecdsa public key of the log and the status of the log (e.g. Active, Inactive).
+func GetRekorPubs() (map[string]RekorPubKey, error) {
+	rekorOnce.Do(func() {
+		rekorPubKeys = make(map[string]RekorPubKey)
+		tufClient, err := tuf.NewFromEnv(context.Background())
+		if err != nil {
+			singletonRekorErr = fmt.Errorf("initializing tuf: %w", err)
+			return
+		}
+		targets, err := tufClient.GetTargetsByMeta(tuf.Rekor, []string{rekorTargetStr})
+		if err != nil {
+			singletonRekorErr = fmt.Errorf("error getting targets: %w", err)
+			return
+		}
+		for _, t := range targets {
+			rekorPubKey, err := cryptoutils.UnmarshalPEMToECDSAKey(t.Target)
+			if err != nil {
+				singletonRekorErr = fmt.Errorf("pem to ecdsa: %w", err)
+				return
+			}
+			keyID, err := GetLogID(rekorPubKey)
+			if err != nil {
+				singletonRekorErr = fmt.Errorf("error generating log ID: %w", err)
+				return
+			}
+			rekorPubKeys[keyID] = RekorPubKey{PubKey: rekorPubKey, Status: t.Status}
+		}
+	})
+
+	return rekorPubKeys, singletonRekorErr
+}

--- a/pkg/rekorpubs/rekorpubs_test.go
+++ b/pkg/rekorpubs/rekorpubs_test.go
@@ -1,0 +1,51 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rekorpubs
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+func resetForTests() {
+	rekorOnce = new(sync.Once)
+}
+
+func TestGetRekorPubs(t *testing.T) {
+	td := t.TempDir()
+	t.Setenv("TUF_ROOT", td)
+
+	rekorPubs, err := GetRekorPubs()
+	defer resetForTests()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rekorPubs) == 0 {
+		t.Error("expected non-empty rekor public keys")
+	}
+
+	for rekorLogID, rekorPub := range rekorPubs {
+		logID, err := GetLogID(rekorPub.PubKey)
+		if err != nil {
+			t.Fatalf("error getting log id %s", err)
+		}
+		if !strings.EqualFold(rekorLogID, logID) {
+			t.Fatalf("log id does not match public key, expected %s, got %s", logID, rekorLogID)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
* Adds a wrapper method to get rekor public keys, to use in cosign

I expect that with this method, we can now set sign/verify opts to include RekorPubKeys, so that people can define this themselves when they cosign as a library. This is how the fulcio roots works as well.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
