### PR TITLE
Lock TUF client during target loading operations

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -64,6 +64,7 @@ var (
 var getRemoteRoot = func() string { return DefaultRemoteRoot }
 
 type TUF struct {
+	sync.Mutex
 	client   *client.Client
 	targets  targetImpl
 	local    client.LocalStore
@@ -348,6 +349,8 @@ func isValidTarget(testTarget []byte, validMeta data.TargetFileMeta) bool {
 }
 
 func (t *TUF) GetTarget(name string) ([]byte, error) {
+	t.Lock()
+	defer t.Unlock()
 	// Get valid target metadata. Does a local verification.
 	validMeta, err := t.client.Target(name)
 	if err != nil {
@@ -368,7 +371,9 @@ func (t *TUF) GetTarget(name string) ([]byte, error) {
 // Get target files by a custom usage metadata tag. If there are no files found,
 // use the fallback target names to fetch the targets by name.
 func (t *TUF) GetTargetsByMeta(usage UsageKind, fallbacks []string) ([]TargetFile, error) {
+	t.Lock()
 	targets, err := t.client.Targets()
+	t.Unlock()
 	if err != nil {
 		return nil, fmt.Errorf("error getting targets: %w", err)
 	}


### PR DESCRIPTION
#### Summary
While https://github.com/sigstore/cosign/pull/1953 resolved access to the TUF cache when running cosign in parallel, cosign now panics when running concurrent operations as threads will try to write read data to the TUF client at the same time.

Here's a sample of the crash:

```
Successfully verified SCT...
Successfully verified SCT...
Successfully verified SCT...
fatal error: concurrent map writes

goroutine 881 [running]:
runtime.throw({0x278fcc7?, 0xc000d5b290?})
	/usr/lib/golang/src/runtime/panic.go:992 +0x71 fp=0xc000b34680 sp=0xc000b34650 pc=0x43a271
runtime.mapassign_faststr(0x2330a00?, 0xc000f1a000?, {0x277a539, 0xc})
	/usr/lib/golang/src/runtime/map_faststr.go:212 +0x39c fp=0xc000b346e8 sp=0xc000b34680 pc=0x4151dc
github.com/theupdateframework/go-tuf/client.(*Client).getLocalMeta(0xc000202000)
	/home/urbano/go/pkg/mod/github.com/theupdateframework/go-tuf@v0.3.0/client/client.go:457 +0x518 fp=0xc000b347e0 sp=0xc000b346e8 pc=0xbf8698
github.com/theupdateframework/go-tuf/client.(*Client).loadLocalSnapshot(0xc000202000)
	/home/urbano/go/pkg/mod/github.com/theupdateframework/go-tuf@v0.3.0/client/delegations.go:65 +0x33 fp=0xc000b34878 sp=0xc000b347e0 pc=0xbfc5f3
github.com/theupdateframework/go-tuf/client.(*Client).getTargetFileMeta(0xc000202000, {0xc000a97921, 0x8})
```

This PR embeds a mutex to the `TUF` struct to allow it to lock itself when loading data using the tuf client. This resolves the above panic. Now, operations to reload the targets from the cache into the client now queue properly.

cc: @asraa @znewman01 @mnm678 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>


#### Ticket Link
Port of https://github.com/sigstore/cosign/pull/1992 to sigstore/sigstore
Follow-up to: https://github.com/sigstore/cosign/pull/1953

#### Release Note

```release-note
Fixed a bug in the tuf client where `cosign` would panic when trying to reload TUF client data concurrently
```
