### PR TITLE
add check if transit return nil data

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -194,9 +194,15 @@ func (h *hashivaultClient) keyCacheLoaderFunction(key string) (data interface{},
 func (h *hashivaultClient) fetchPublicKey(_ context.Context) (crypto.PublicKey, error) {
 	client := h.client.Logical()
 
-	keyResult, err := client.Read(fmt.Sprintf("/%s/keys/%s", h.transitSecretEnginePath, h.keyPath))
+	path := fmt.Sprintf("/%s/keys/%s", h.transitSecretEnginePath, h.keyPath)
+
+	keyResult, err := client.Read(path)
 	if err != nil {
 		return nil, fmt.Errorf("public key: %w", err)
+	}
+
+	if keyResult == nil {
+		return nil, fmt.Errorf("could not read data from transit key path: %s", path)
 	}
 
 	keysData, hasKeys := keyResult.Data["keys"]

--- a/pkg/signature/kms/hashivault/e2e_test.go
+++ b/pkg/signature/kms/hashivault/e2e_test.go
@@ -330,6 +330,16 @@ func (suite *VaultSuite) TestSignWithDifferentTransitSecretEnginePath() {
 	assert.Nil(suite.T(), err)
 }
 
+func (suite *VaultSuite) TestInvalidPublicKey() {
+	var provider *SignerVerifier
+	var err error
+	assert.NotPanics(suite.T(), func() {
+		provider, _ = LoadSignerVerifier("hashivault://pki_int", crypto.SHA256)
+		_, err = provider.client.fetchPublicKey(context.Background())
+	})
+	assert.NotNil(suite.T(), err)
+}
+
 func (suite *VaultSuite) TestSignWithDifferentTransitSecretEnginePathOpts() {
 	provider := suite.GetProvider("testsign", options.WithRPCAuthOpts(options.RPCAuth{Path: "somerandompath"}))
 


### PR DESCRIPTION
Fixes a panic error that occured in https://github.com/sigstore/fulcio/issues/654

Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixed a panic error where vault client return empty data from transit engine
```
