### PR TITLE
Keep calm and don't panic: enable and apply forcetypeassert lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
   - depguard
   - errcheck
   - errorlint
+  - forcetypeassert
   - gofmt
   - goimports
   - gosec

--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -58,10 +58,14 @@ func startRedirectListener(state, htmlPage, redirectURL string, codeCh chan stri
 			return nil, nil, err
 		}
 
-		port := listener.Addr().(*net.TCPAddr).Port
+		addr, ok := listener.Addr().(*net.TCPAddr)
+		if !ok {
+			return nil, nil, fmt.Errorf("listener addr is not TCPAddr")
+		}
+
 		urlListener = &url.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("localhost:%d", port),
+			Host:   fmt.Sprintf("localhost:%d", addr.Port),
 			Path:   "/auth/callback",
 		}
 	} else {

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -148,10 +148,14 @@ func startRedirectListener(state, htmlPage, redirectURL string, doneCh chan stri
 			return nil, nil, err
 		}
 
-		port := listener.Addr().(*net.TCPAddr).Port
+		addr, ok := listener.Addr().(*net.TCPAddr)
+		if !ok {
+			return nil, nil, fmt.Errorf("listener addr is not TCPAddr")
+		}
+
 		urlListener = &url.URL{
 			Scheme: "http",
-			Host:   fmt.Sprintf("localhost:%d", port),
+			Host:   fmt.Sprintf("localhost:%d", addr.Port),
 			Path:   "/auth/callback",
 		}
 	} else {

--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -152,7 +152,10 @@ func LoadED25519SignerVerifier(priv ed25519.PrivateKey) (*ED25519SignerVerifier,
 	if err != nil {
 		return nil, fmt.Errorf("initializing signer: %w", err)
 	}
-	pub := priv.Public().(ed25519.PublicKey)
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("given key is not ed25519.PublicKey: %w", err)
+	}
 	verifier, err := LoadED25519Verifier(pub)
 	if err != nil {
 		return nil, fmt.Errorf("initializing verifier: %w", err)

--- a/pkg/signature/ed25519_test.go
+++ b/pkg/signature/ed25519_test.go
@@ -41,7 +41,10 @@ func TestED25519SignerVerifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error unmarshalling public key: %v", err)
 	}
-	edPriv := privateKey.(ed25519.PrivateKey)
+	edPriv, ok := privateKey.(ed25519.PrivateKey)
+	if !ok {
+		t.Fatalf("expected ed25519.PrivateKey: %v", err)
+	}
 
 	sv, err := LoadED25519SignerVerifier(edPriv)
 	if err != nil {
@@ -64,7 +67,10 @@ func TestED25519Verifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error unmarshalling public key: %v", err)
 	}
-	edPub := publicKey.(ed25519.PublicKey)
+	edPub, ok := publicKey.(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("public key is not ed25519")
+	}
 
 	v, err := LoadED25519Verifier(edPub)
 	if err != nil {

--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -279,7 +279,12 @@ func (g *gcpClient) getCKV() (*cryptoKeyVersion, error) {
 		return nil, err
 	}
 
-	return kmsVersionInt.(*cryptoKeyVersion), nil
+	kv, ok := kmsVersionInt.(*cryptoKeyVersion)
+	if !ok {
+		return nil, fmt.Errorf("could not parse kms version cache value as CryptoKeyVersion")
+	}
+
+	return kv, nil
 }
 
 func (g *gcpClient) sign(ctx context.Context, digest []byte, alg crypto.Hash, crc uint32) ([]byte, error) {

--- a/pkg/signature/sv_test.go
+++ b/pkg/signature/sv_test.go
@@ -78,7 +78,11 @@ func testingSigner(t *testing.T, s Signer, alg string, hashFunc crypto.Hash, mes
 		t.Errorf("unexpected error passing nil options: %v", err)
 	}
 
-	cs := s.(crypto.Signer)
+	cs, ok := s.(crypto.Signer)
+	if !ok {
+		t.Fatalf("expected crypto.Signer")
+	}
+
 	if _, err := cs.Sign(nil, nil, nil); err == nil {
 		t.Errorf("no error passing nil for all args to Sign: %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
I was playing with Vault KMS and hit two different panic cases. And both of are actually casting error:
1. [keysData.(map[string]interface{})](https://github.com/sigstore/sigstore/blob/9dde75d80cf82ad42401b08165151d947cdcd538/pkg/signature/kms/hashivault/client.go#L208)
2. [latestVersion.(json.Number)](https://github.com/sigstore/sigstore/blob/9dde75d80cf82ad42401b08165151d947cdcd538/pkg/signature/kms/hashivault/client.go#L213)

I'm not so sure which cases caused this problem. So I thought It would be nice to have a [forcetypeassert](https://github.com/gostaticanalysis/forcetypeassert) analyzer in the golangci-lint.

I also had to remove the following line because forcetypeassert still complains about: `type assertion must be checked`

```
return fmt.Errorf("data type assertion for field `valid` failed: %T %#v", valid.(bool), valid.(bool))
```

I could have passed a `//nolinter:` but I thought in both cases the following above throws panic, right? @blz-ea 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Enable forcetypeassert linter in golangic-lint
```
