### PR TITLE
oauthflow: Fix recursive call for GetOutput.

### DIFF
--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -154,7 +154,7 @@ func (i *InteractiveIDTokenGetter) GetOutput() io.Writer {
 	if i.Output == nil {
 		return os.Stderr
 	}
-	return i.GetOutput()
+	return i.Output
 }
 
 func startRedirectListener(state, htmlPage, redirectURL string, doneCh chan string, errCh chan error) (*http.Server, *url.URL, error) {

--- a/pkg/oauthflow/interactive_test.go
+++ b/pkg/oauthflow/interactive_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oauthflow
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestInteractiveFlow_IO(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		f := &InteractiveIDTokenGetter{}
+		if f.GetInput() != os.Stdin {
+			t.Error("expected stdin")
+		}
+		if f.GetOutput() != os.Stderr {
+			t.Error("expected stderr")
+		}
+	})
+
+	t.Run("buffer", func(t *testing.T) {
+		b := new(bytes.Buffer)
+		f := &InteractiveIDTokenGetter{
+			Input:  b,
+			Output: b,
+		}
+		if f.GetInput() != b {
+			t.Error("expected buffer")
+		}
+		if f.GetOutput() != b {
+			t.Error("expected buffer")
+		}
+	})
+}


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

Also adds basic tests to make sure this works.

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixes GetOutput infinite recursion behavior for interactive oauthflow.
```
