### PR TITLE
Remove err from type cast failures

### DIFF
--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -154,7 +154,7 @@ func LoadED25519SignerVerifier(priv ed25519.PrivateKey) (*ED25519SignerVerifier,
 	}
 	pub, ok := priv.Public().(ed25519.PublicKey)
 	if !ok {
-		return nil, fmt.Errorf("given key is not ed25519.PublicKey: %w", err)
+		return nil, fmt.Errorf("given key is not ed25519.PublicKey")
 	}
 	verifier, err := LoadED25519Verifier(pub)
 	if err != nil {

--- a/pkg/signature/ed25519_test.go
+++ b/pkg/signature/ed25519_test.go
@@ -43,7 +43,7 @@ func TestED25519SignerVerifier(t *testing.T) {
 	}
 	edPriv, ok := privateKey.(ed25519.PrivateKey)
 	if !ok {
-		t.Fatalf("expected ed25519.PrivateKey: %v", err)
+		t.Fatalf("expected ed25519.PrivateKey")
 	}
 
 	sv, err := LoadED25519SignerVerifier(edPriv)


### PR DESCRIPTION
#### Summary
A cleanup for #522: Remove err from type cast failures

In both cases the error value is unrelated to the cast failure, and in fact guaranteed to be `nil` on that code path.

#### Ticket Link

#### Release Note
```release-note
NONE
```
