### PR TITLE
fix gosec lint G112 errors

### DIFF
--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -83,6 +83,9 @@ func startRedirectListener(state, htmlPage, redirectURL string, codeCh chan stri
 	s := &http.Server{
 		Addr:    urlListener.Host,
 		Handler: m,
+
+		// an arbitrary reasonable value to fix gosec lint error
+		ReadHeaderTimeout: 2 * time.Second,
 	}
 
 	m.HandleFunc(urlListener.Path, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -194,6 +194,9 @@ func startRedirectListener(state, htmlPage, redirectURL string, doneCh chan stri
 	s := &http.Server{
 		Addr:    urlListener.Host,
 		Handler: m,
+
+		// an arbitrary reasonable value to fix gosec lint error
+		ReadHeaderTimeout: 2 * time.Second,
 	}
 
 	m.HandleFunc(urlListener.Path, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This is causing ci to fail e.g. https://github.com/sigstore/sigstore/runs/7435765870?check_suite_focus=true