### PR TITLE
New : Ensure code coverage is met

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,5 +56,8 @@ jobs:
     - name: Test
       run: go test -v ./...
 
+    - name: Coverage # ensures the code coverage is meeting the desired threshold.
+      run: make coverage
+
     - name: Ensure no files were modified as a result of the build
       run: git update-index --refresh && git diff-index --quiet HEAD -- || git diff --exit-code

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sigstore
 *fuzz.zip
 bin*
 .vscode/*
+coverage

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all pkg test test-e2e clean lint fuzz help
+.PHONY: all pkg test test-e2e clean lint fuzz help coverage
 
-all: pkg fuzz
+all: pkg fuzz coverage
 
 TOOLS_DIR := hack/tools
 TOOLS_BIN_DIR := $(abspath $(TOOLS_DIR)/bin)
@@ -24,6 +24,8 @@ INTEGRATION_TEST_DIR := ./test/e2e
 GO-FUZZ-BUILD := $(TOOLS_BIN_DIR)/go-fuzz-build
 GENSRC = pkg/generated/models/%.go pkg/generated/client/%.go
 SRCS = $(shell find pkg -iname "*.go"|grep -v pkg/generated) $(GENSRC)
+TEST_COVERAGE_PERCENTAGE = 70
+COVERAGE_THRESHOLD_FILE = coveragethreshold.json
 
 GOLANGCI_LINT_DIR = $(shell pwd)/bin
 GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
@@ -47,6 +49,9 @@ pkg: ## Build pkg
 
 test: ## Run Tests
 	go test ./...
+
+coverage: test ## Run Coverage checks
+	@go test  -coverprofile=coverage ./... | THRESHOLD_FILE=$(COVERAGE_THRESHOLD_FILE) COVERAGE_PERCENTAGE=$(TEST_COVERAGE_PERCENTAGE) go run ./hack/codecoverage/main.go
 
 test-e2e: ## Run E2E Tests
 	cd $(INTEGRATION_TEST_DIR); ./e2e-test.sh

--- a/coveragethreshold.json
+++ b/coveragethreshold.json
@@ -1,0 +1,17 @@
+{
+  "github.com/sigstore/sigstore/pkg/cryptoutils": 71.2,
+  "github.com/sigstore/sigstore/pkg/oauth/internal" :88.7,
+  "github.com/sigstore/sigstore/pkg/oauth/oidc": 0.8,
+  "github.com/sigstore/sigstore/pkg/oauthflow": 36.4,
+  "github.com/sigstore/sigstore/pkg/signature": 66.5,
+  "github.com/sigstore/sigstore/pkg/signature/dsse": 77.1,
+  "github.com/sigstore/sigstore/pkg/signature/kms": 50.0,
+  "github.com/sigstore/sigstore/pkg/signature/kms/aws": 5.1,
+  "github.com/sigstore/sigstore/pkg/signature/kms/azure": 11.3,
+  "github.com/sigstore/sigstore/pkg/signature/kms/fake": 85.3,
+  "github.com/sigstore/sigstore/pkg/signature/kms/gcp": 18.8,
+  "github.com/sigstore/sigstore/pkg/signature/kms/hashivault":3.6,
+  "github.com/sigstore/sigstore/pkg/signature/payload": 43.8,
+  "github.com/sigstore/sigstore/pkg/signature/ssh": 65.3,
+  "github.com/sigstore/sigstore/pkg/tuf": 66.2
+}

--- a/hack/codecoverage/README.md
+++ b/hack/codecoverage/README.md
@@ -1,0 +1,43 @@
+# Go Coverage tool
+
+The goal of the coverage tool is to measure the coverage of the code base for Golang.
+
+## Usage
+Execute the following command to get the coverage and store it in a file:
+1. `go test  -coverprofile=coverage ./... | THRESHOLD_FILE=./coverage.json COVERAGE_PERCENTAGE=70 go run ./hack/codecoverage/main.go`
+2. The `THRESHOLD_FILE` is the path to the file containing the coverage threshold.
+3. The THRESHOLD_FILE contains the percentage of the code coverage that is required to pass for certain packages. This is usually because they don't match the desired coverage.
+```json
+    {
+    "github.com/sigstore/sigstore/pkg/cryptoutils": 71.2,
+    "github.com/sigstore/sigstore/pkg/oauth/internal" :88.7,
+    "github.com/sigstore/sigstore/pkg/oauth/oidc": 0.8,
+    "github.com/sigstore/sigstore/pkg/oauthflow": 36.4,
+    "github.com/sigstore/sigstore/pkg/signature": 66.5,
+    "github.com/sigstore/sigstore/pkg/signature/dsse": 77.1,
+    "github.com/sigstore/sigstore/pkg/signature/kms": 50.0,
+    "github.com/sigstore/sigstore/pkg/signature/kms/aws": 5.1,
+    "github.com/sigstore/sigstore/pkg/signature/kms/azure": 11.3,
+    "github.com/sigstore/sigstore/pkg/signature/kms/fake": 85.3,
+    "github.com/sigstore/sigstore/pkg/signature/kms/gcp": 18.8,
+    "github.com/sigstore/sigstore/pkg/signature/kms/hashivault":3.6,
+    "github.com/sigstore/sigstore/pkg/signature/payload": 43.8,
+    "github.com/sigstore/sigstore/pkg/signature/ssh": 65.3,
+    "github.com/sigstore/sigstore/pkg/tuf": 66.2
+    }
+```
+3. The `COVERAGE_PERCENTAGE` is the percentage of the code coverage that is required to pass for all the packages except the ones that are mentioned in the `THRESHOLD_FILE`.
+4. The coverage tool will fail if the coverage is below the threshold for any package.
+``` shell
+2022/07/29 16:14:41 github.com/sigstore/sigstore/pkg/foo is below the threshold of 71.000000
+exit status 1
+```
+
+### Design choices
+
+1. The coverage tool should not depend on any other tools. It should work of the results from the `go test` command.
+2. Coverage threshold should be configurable for each repository - for example `70%` within the repository.
+3. A setting file should override the coverage threshold for a given package within the repository. `github.com/foo/bar/xyz : 61`
+4. The coverage tool should use native `go` tools and shouldn't depend on external vendors.
+5. The coverage tool should be configurable as part of the PR to fail if the desired threshold is not met.
+6. Contributors should be able to run it locally if desired before doing a PR.

--- a/hack/codecoverage/go.mod
+++ b/hack/codecoverage/go.mod
@@ -1,0 +1,3 @@
+module github.com/sigstore/sigstore/hack/coverage
+
+go 1.17

--- a/hack/codecoverage/main.go
+++ b/hack/codecoverage/main.go
@@ -1,0 +1,103 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func main() {
+	thresholdFile := os.Getenv("THRESHOLD_FILE")
+	if thresholdFile == "" {
+		log.Fatalf("THRESHOLD_FILE environment variable is not set")
+	}
+	thresholdMap, err := parseCoverageThreshold(thresholdFile)
+	if err != nil {
+		log.Fatalf("Error parsing threshold file: %v", err)
+	}
+	coveragePercentage := os.Getenv("COVERAGE_PERCENTAGE")
+	if coveragePercentage == "" {
+		log.Fatalf("COVERAGE_PERCENTAGE environment variable is not set")
+	}
+	coveragePercentageFloat, err := strconv.ParseFloat(coveragePercentage, 32)
+	if err != nil {
+		log.Fatalf("Error parsing coverage percentage: %v", err)
+	}
+	// read stream from stdin
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.Contains(line, "coverage: ") {
+			parts := strings.Fields(line)
+			if len(parts) < 5 {
+				continue
+			}
+			percentage, err := strconv.ParseFloat(strings.Trim(parts[4], "%"), 32)
+			if err != nil {
+				log.Fatalf("invalid line: %s", line)
+			}
+			pack := parts[1]
+			if val, ok := thresholdMap[pack]; !ok {
+				if float32(int(percentage*100)/100) < float32(int(coveragePercentageFloat*100)/100) {
+					log.Fatalf("coverage for %s is below threshold: %f < %f", pack, percentage, coveragePercentageFloat)
+				}
+			} else {
+				if float32(int(percentage*100)/100) < float32(int(val*100)/100) {
+					log.Fatalf("coverage for %s is below threshold: %f < %f", pack, percentage, val)
+				}
+			}
+		}
+	}
+
+}
+
+// parseCoverageThreshold parses the threshold file and returns a map.
+func parseCoverageThreshold(fileName string) (map[string]float64, error) {
+	// Here is an example of the threshold file:
+	/*
+		{
+			  "github.com/sigstore/sigstore/pkg/cryptoutils": 71.2,
+			  "github.com/sigstore/sigstore/pkg/oauth/internal" :88.7,
+			  "github.com/sigstore/sigstore/pkg/oauth/oidc": 0.8,
+			  "github.com/sigstore/sigstore/pkg/oauthflow": 36.4,
+			  "github.com/sigstore/sigstore/pkg/signature": 66.5,
+			  "github.com/sigstore/sigstore/pkg/signature/dsse": 77.1,
+			  "github.com/sigstore/sigstore/pkg/signature/kms": 50.0,
+			  "github.com/sigstore/sigstore/pkg/signature/kms/aws": 5.1,
+			  "github.com/sigstore/sigstore/pkg/signature/kms/azure": 11.3,
+			  "github.com/sigstore/sigstore/pkg/signature/kms/fake": 85.3,
+			  "github.com/sigstore/sigstore/pkg/signature/kms/gcp": 18.8,
+			  "github.com/sigstore/sigstore/pkg/signature/kms/hashivault":3.6,
+			  "github.com/sigstore/sigstore/pkg/signature/payload": 43.8,
+			  "github.com/sigstore/sigstore/pkg/signature/ssh": 65.3,
+			  "github.com/sigstore/sigstore/pkg/tuf": 66.2
+			}
+	*/
+	f, err := os.Open(fileName)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	thresholdMap := make(map[string]float64)
+	if err := json.NewDecoder(f).Decode(&thresholdMap); err != nil {
+		return nil, err
+	}
+	return thresholdMap, nil
+}


### PR DESCRIPTION
#### Summary
- This will enable the desired code coverage to be met for the project
- The coverage is set to 70 to start with. This setting is in the `Makefile`. 
- The `coveragethreshold.json` is an override for packages with different coverage needs from the global coverage threshold.
For example `github.com/sigstore/sigstore/pkg/oauthflow` package has only coverage of `36.4` percentage. The tool would ensure for the `github.com/sigstore/sigstore/pkg/oauthflow` the coverage doesn't fall below `36.4`
- The code coverage tool uses the standard go tool.
-  This PR will not break on the existing package coverage. Only new code changes if they fall below the desired coverage requirements will fail.
- https://github.com/sigstore/sigstore/issues/211

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>


#### Release Note
NONE

#### Documentation
NONE