### PR TITLE
Fix issue #600. When using StaticTokenGetter do not make network calls.

### DIFF
--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -82,6 +82,11 @@ var PublicInstanceMicrosoftIDTokenGetter = &InteractiveIDTokenGetter{
 // OIDConnect requests an OIDC Identity Token from the specified issuer using the specified client credentials and TokenGetter
 // NOTE: If the redirectURL is empty a listener on localhost:0 is configured with '/auth/callback' as default path.
 func OIDConnect(issuer, id, secret, redirectURL string, tg TokenGetter) (*OIDCIDToken, error) {
+	// Check if it's a StaticTokenGetter since NewProvider below will make
+	// network calls unnecessarily and they are ignored.
+	if sg, ok := tg.(*StaticTokenGetter); ok {
+		return sg.GetIDToken(nil, oauth2.Config{})
+	}
 	provider, err := oidc.NewProvider(context.Background(), issuer)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When using StaticTokenGetter do not make network calls.

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix Issue #600 
When using StaticTokenGetter do not use OIDC discovery so that this flow works even without network connectivity.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->