### PR TITLE
Use well-known OIDC config for device endpoints

### DIFF
--- a/pkg/oauthflow/device_test.go
+++ b/pkg/oauthflow/device_test.go
@@ -104,7 +104,7 @@ func (td *testDriver) handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	switch r.URL.Path {
-	case "/device/token", "/device/code":
+	case "/token", "/device/code":
 		_, _ = w.Write(b)
 	default:
 		w.WriteHeader(http.StatusBadRequest)
@@ -125,8 +125,6 @@ func TestDeviceFlowTokenGetter_deviceFlow(t *testing.T) {
 		MessagePrinter: td.writeMsg,
 		Sleeper:        func(_ time.Duration) {},
 		Issuer:         ts.URL,
-		TokenURL:       ts.URL + "/device/token",
-		CodeURL:        ts.URL + "/device/code",
 	}
 	p, pErr := oidc.NewProvider(context.Background(), ts.URL)
 	if pErr != nil {


### PR DESCRIPTION
This patch adds the ability to use the well-known OIDC configuration to discover the device authorization and token endpoints used during a device code flow to fetch an identity token. This enables support for device code flow for OIDC providers other than `oauth2.sigstore.dev`.

Signed-off-by: Bob Callaway <bcallaway@google.com>