### PR TITLE
Add a more friendly error in pubkey failure

### DIFF
--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -52,7 +52,13 @@ func UnmarshalPEMToPublicKey(pemBytes []byte) (crypto.PublicKey, error) {
 	if derBytes == nil {
 		return nil, errors.New("PEM decoding failed")
 	}
-	return x509.ParsePKIXPublicKey(derBytes.Bytes)
+	switch derBytes.Type {
+	case string(PublicKeyPEMType):
+		return x509.ParsePKIXPublicKey(derBytes.Bytes)
+	default:
+		return nil, fmt.Errorf("unknown Public key PEM file type: %v. Are you passing the correct public key?",
+			derBytes.Type)
+	}
 }
 
 // MarshalPublicKeyToDER converts a crypto.PublicKey into a PKIX, ASN.1 DER byte slice


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Closes #622

When passing a wrong public key to the verify function, it will return an unfriendly error. Instead we can just let users know they are passing the wrong public key format

#### Release Note
Return a friendly error when an invalid key format is passed

#### Documentation
No change in docs