### PR TITLE
Add support for parsing PKCS#1 priv/pub keys, SEC1 priv keys

### DIFF
--- a/pkg/cryptoutils/privatekey.go
+++ b/pkg/cryptoutils/privatekey.go
@@ -31,7 +31,11 @@ import (
 
 const (
 	// PrivateKeyPEMType is the string "PRIVATE KEY" to be used during PEM encoding and decoding
-	PrivateKeyPEMType                PEMType = "PRIVATE KEY"
+	PrivateKeyPEMType PEMType = "PRIVATE KEY"
+	// ECPrivateKeyPEMType is the string "EC PRIVATE KEY" used to parse SEC 1 EC private keys
+	ECPrivateKeyPEMType PEMType = "EC PRIVATE KEY"
+	// PKCS1PrivateKeyPEMType is the string "RSA PRIVATE KEY" used to parse PKCS#1-encoded private keys
+	PKCS1PrivateKeyPEMType           PEMType = "RSA PRIVATE KEY"
 	encryptedCosignPrivateKeyPEMType PEMType = "ENCRYPTED COSIGN PRIVATE KEY"
 	// EncryptedSigstorePrivateKeyPEMType is the string "ENCRYPTED SIGSTORE PRIVATE KEY" to be used during PEM encoding and decoding
 	EncryptedSigstorePrivateKeyPEMType PEMType = "ENCRYPTED SIGSTORE PRIVATE KEY"
@@ -106,6 +110,10 @@ func UnmarshalPEMToPrivateKey(pemBytes []byte, pf PassFunc) (crypto.PrivateKey, 
 	switch derBlock.Type {
 	case string(PrivateKeyPEMType):
 		return x509.ParsePKCS8PrivateKey(derBlock.Bytes)
+	case string(PKCS1PrivateKeyPEMType):
+		return x509.ParsePKCS1PrivateKey(derBlock.Bytes)
+	case string(ECPrivateKeyPEMType):
+		return x509.ParseECPrivateKey(derBlock.Bytes)
 	case string(EncryptedSigstorePrivateKeyPEMType), string(encryptedCosignPrivateKeyPEMType):
 		derBytes := derBlock.Bytes
 		if pf != nil {
@@ -123,7 +131,7 @@ func UnmarshalPEMToPrivateKey(pemBytes []byte, pf PassFunc) (crypto.PrivateKey, 
 
 		return x509.ParsePKCS8PrivateKey(derBytes)
 	}
-	return nil, fmt.Errorf("unknown PEM file type: %v", derBlock.Type)
+	return nil, fmt.Errorf("unknown private key PEM file type: %v", derBlock.Type)
 }
 
 // MarshalPrivateKeyToDER converts a crypto.PrivateKey into a PKCS8 ASN.1 DER byte slice
@@ -134,7 +142,7 @@ func MarshalPrivateKeyToDER(priv crypto.PrivateKey) ([]byte, error) {
 	return x509.MarshalPKCS8PrivateKey(priv)
 }
 
-// MarshalPrivateKeyToPEM converts a crypto.PrivateKey into a PEM-encoded byte slice
+// MarshalPrivateKeyToPEM converts a crypto.PrivateKey into a PKCS#8 PEM-encoded byte slice
 func MarshalPrivateKeyToPEM(priv crypto.PrivateKey) ([]byte, error) {
 	derBytes, err := MarshalPrivateKeyToDER(priv)
 	if err != nil {

--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -37,6 +37,8 @@ import (
 const (
 	// PublicKeyPEMType is the string "PUBLIC KEY" to be used during PEM encoding and decoding
 	PublicKeyPEMType PEMType = "PUBLIC KEY"
+	// PKCS1PublicKeyPEMType is the string "RSA PUBLIC KEY" used to parse PKCS#1-encoded public keys
+	PKCS1PublicKeyPEMType PEMType = "RSA PUBLIC KEY"
 )
 
 // subjectPublicKeyInfo is used to construct a subject key ID.
@@ -55,6 +57,8 @@ func UnmarshalPEMToPublicKey(pemBytes []byte) (crypto.PublicKey, error) {
 	switch derBytes.Type {
 	case string(PublicKeyPEMType):
 		return x509.ParsePKIXPublicKey(derBytes.Bytes)
+	case string(PKCS1PublicKeyPEMType):
+		return x509.ParsePKCS1PublicKey(derBytes.Bytes)
 	default:
 		return nil, fmt.Errorf("unknown Public key PEM file type: %v. Are you passing the correct public key?",
 			derBytes.Type)


### PR DESCRIPTION
This adds support for parsing RSA public and private keys, and SEC 1 EC
private keys. This should reduce unexpected format errors for library
users.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Added support for parsing PKCS#1 private and public keys, and SEC 1 private keys

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->