### PR TITLE
ignore pre-existing lint errors

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -54,3 +54,4 @@ jobs:
         timeout-minutes: 5
         with:
           version: latest
+          only-new-issues: true


### PR DESCRIPTION
Lint action findings unrelated to PRs are annoying and useless, e.g. https://github.com/sigstore/sigstore/runs/8023362038?check_suite_focus=true