### PR TITLE
oauthflow/interactive: Fix oob flow

### DIFF
--- a/pkg/oauth/oidc/interactive.go
+++ b/pkg/oauth/oidc/interactive.go
@@ -37,9 +37,8 @@ const oobRedirectURI = "urn:ietf:wg:oauth:2.0:oob"
 type browserOpener func(url string) error
 
 func doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOption) string {
-	if cfg.RedirectURL == "" {
-		cfg.RedirectURL = oobRedirectURI
-	}
+	cfg.RedirectURL = oobRedirectURI
+
 	authURL := cfg.AuthCodeURL(stateToken, opts...)
 	fmt.Fprintln(os.Stderr, "Go to the following link in a browser:\n\n\t", authURL)
 	fmt.Fprintf(os.Stderr, "Enter verification code: ")

--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -128,14 +128,15 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 }
 
 func (i *InteractiveIDTokenGetter) doOobFlow(cfg *oauth2.Config, stateToken string, opts []oauth2.AuthCodeOption) string {
-	if cfg.RedirectURL == "" {
-		cfg.RedirectURL = oobRedirectURI
-	}
+	cfg.RedirectURL = oobRedirectURI
+
 	authURL := cfg.AuthCodeURL(stateToken, opts...)
 	fmt.Fprintln(i.GetOutput(), "Go to the following link in a browser:\n\n\t", authURL)
 	fmt.Fprintf(i.GetOutput(), "Enter verification code: ")
 	var code string
-	fmt.Fscanln(i.GetInput(), &code)
+	fmt.Fscanf(i.GetInput(), "%s", &code)
+	// New line in case read input doesn't move cursor to next line.
+	fmt.Fprintln(i.GetOutput())
 	return code
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change does 2 things:

1. Always sets oob URL for the oob flow. Reverts 8c6a840f - w.r.t. `pkg/oauth/oidc`: this looks largely duplicative of pkg/oauthflow so we probably want to delete / merge these together in another PR - both cosign and gitsign are using oauthflow. 🤷 
2. Changes Fscanln to Fscanf - Fscanln wasn't reading values unless it received EOF, making it non-obvious that a value was successfully read (especially in gitsign where we use the TTY directly so values don't populate to stdout).

Verified this works as expected for gitsign.

Fixes #594 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

🐛 Fixes OoB flow.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->