### PR TITLE
Handle certificates that end in newline

### DIFF
--- a/pkg/cryptoutils/certificate.go
+++ b/pkg/cryptoutils/certificate.go
@@ -59,6 +59,7 @@ func MarshalCertificatesToPEM(certs []*x509.Certificate) ([]byte, error) {
 func UnmarshalCertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) {
 	result := []*x509.Certificate{}
 	remaining := pemBytes
+	remaining = bytes.TrimSpace(remaining)
 
 	for len(remaining) > 0 {
 		var certDer *pem.Block
@@ -83,6 +84,7 @@ func UnmarshalCertificatesFromPEM(pemBytes []byte) ([]*x509.Certificate, error) 
 func UnmarshalCertificatesFromPEMLimited(pemBytes []byte, iterations int) ([]*x509.Certificate, error) {
 	result := []*x509.Certificate{}
 	remaining := pemBytes
+	remaining = bytes.TrimSpace(remaining)
 
 	count := 0
 	for len(remaining) > 0 {

--- a/pkg/cryptoutils/certificate_test.go
+++ b/pkg/cryptoutils/certificate_test.go
@@ -127,8 +127,19 @@ func TestCertificatesFromPEM(t *testing.T) {
 			expected: []*x509.Certificate{cert1},
 		},
 		{
+			name:     "one cert with trailing newline",
+			pemBytes: append([]byte(cert1PEM), '\n'),
+
+			expected: []*x509.Certificate{cert1},
+		},
+		{
 			name:     "two certs",
 			pemBytes: []byte(cert1PEM + cert2PEM),
+			expected: []*x509.Certificate{cert1, cert2},
+		},
+		{
+			name:     "two certs with newline between and after certificates",
+			pemBytes: []byte(cert1PEM + "\n" + cert2PEM + "\n"),
 			expected: []*x509.Certificate{cert1, cert2},
 		},
 		{


### PR DESCRIPTION
This fixes a bug where certificates with trailing newlines would not be parseable.

Fixes https://github.com/sigstore/cosign/issues/2237

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fixed bug when unmarshalling certificates with trailing newline

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->