### PR TITLE
Handle invalid elliptic curve gracefully when verifying signature

### DIFF
--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -185,9 +185,9 @@ func (e ECDSAVerifier) VerifySignature(signature, message io.Reader, opts ...Ver
 		return fmt.Errorf("reading signature: %w", err)
 	}
 
-	// Without this check, VerifyASN1 panics on an invalid curve.
+	// Without this check, VerifyASN1 panics on an invalid key.
 	if !e.publicKey.Curve.IsOnCurve(e.publicKey.X, e.publicKey.Y) {
-		return fmt.Errorf("invalid ECDSA curve for %s", e.publicKey.Params().Name)
+		return fmt.Errorf("invalid ECDSA public key for %s", e.publicKey.Params().Name)
 	}
 
 	if !ecdsa.VerifyASN1(e.publicKey, digest, sigBytes) {

--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -181,6 +181,11 @@ func (e ECDSAVerifier) VerifySignature(signature, message io.Reader, opts ...Ver
 		return fmt.Errorf("reading signature: %w", err)
 	}
 
+	// Without this check, VerifyASN1 panics on an invalid curve.
+	if !e.publicKey.Curve.IsOnCurve(e.publicKey.X, e.publicKey.Y) {
+		return fmt.Errorf("invalid ECDSA curve for %s", e.publicKey.Params().Name)
+	}
+
 	if !ecdsa.VerifyASN1(e.publicKey, digest, sigBytes) {
 		return errors.New("invalid signature when validating ASN.1 encoded signature")
 	}

--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -167,6 +167,10 @@ func (e ECDSAVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error)
 //
 // All other options are ignored if specified.
 func (e ECDSAVerifier) VerifySignature(signature, message io.Reader, opts ...VerifyOption) error {
+	if e.publicKey == nil {
+		return errors.New("no public key set for ECDSAVerifier")
+	}
+
 	digest, _, err := ComputeDigestForVerifying(message, e.hashFunc, ecdsaSupportedVerifyHashFuncs, opts...)
 	if err != nil {
 		return err

--- a/pkg/signature/ecdsa_test.go
+++ b/pkg/signature/ecdsa_test.go
@@ -130,7 +130,7 @@ func TestECDSALoadVerifierInvalidCurve(t *testing.T) {
 		fmt.Println(err)
 	}
 
-	if err := verifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err == nil || !strings.Contains(err.Error(), "invalid ECDSA curve") {
+	if err := verifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err == nil || !strings.Contains(err.Error(), "invalid ECDSA public key") {
 		t.Fatalf("expected error verifying signature with invalid curve, got %v", err)
 	}
 }

--- a/pkg/signature/ecdsa_test.go
+++ b/pkg/signature/ecdsa_test.go
@@ -95,6 +95,18 @@ func TestECDSASignerVerifierUnsupportedHash(t *testing.T) {
 	}
 }
 
+func TestECDSALoadVerifierWithoutKey(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	v, err := LoadECDSAVerifier(&key.PublicKey, crypto.SHA256)
+	if err != nil {
+		t.Fatalf("error creating verifier: %v", err)
+	}
+	v.publicKey = nil
+	if err := v.VerifySignature(nil, nil); err == nil || !strings.Contains(err.Error(), "no public key") {
+		t.Fatalf("expected error without public key, got: %v", err)
+	}
+}
+
 // TestECDSALoadVerifierInvalidCurve tests gracefully handling an invalid curve.
 func TestECDSALoadVerifierInvalidCurve(t *testing.T) {
 	data := []byte{1}


### PR DESCRIPTION
An invalid curve caused a panic when verifying. Note that this does not affect Rekor or Fulcio. In both cases, an invalid curve will be caught when unmarshalling the PKIX public key, which checks for curve validity.

Caught by OSS-Fuzz!

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->