### PR TITLE
Fix remoteFromMirror with GCS bucket

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -698,7 +698,7 @@ func remoteFromMirror(mirror string) (client.RemoteStore, error) {
 	// This is for compatibility with specifying a GCS bucket remote.
 	u, parseErr := url.ParseRequestURI(mirror)
 	if parseErr != nil {
-		mirror = fmt.Sprintf("https://%s.storage.googleapis.com", mirror)
+		return client.HTTPRemoteStore(fmt.Sprintf("https://%s.storage.googleapis.com", mirror), nil, nil)
 	}
 	if u.Scheme != "file" {
 		return client.HTTPRemoteStore(mirror, nil, nil)

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -789,3 +789,28 @@ func TestTargetsSubfolder(t *testing.T) {
 	}
 	checkTargetsAndMeta(t, tuf, []string{newTarget})
 }
+
+func Test_remoteFromMirror(t *testing.T) {
+	// test GCS mirror
+	mirror := "test-bucket"
+	_, err := remoteFromMirror(mirror)
+	if err != nil {
+		t.Fatalf("unexpected error with GCS mirror: %v", err)
+	}
+
+	// test HTTP mirror
+	mirror = "https://tuf-root-staging.storage.googleapis.com"
+	_, err = remoteFromMirror(mirror)
+	if err != nil {
+		t.Fatalf("unexpected error with GCS mirror: %v", err)
+	}
+
+	// test local mirror
+	tufRoot := t.TempDir()
+	os.Mkdir(fmt.Sprintf("%s/targets", tufRoot), 0750)
+	mirror = fmt.Sprintf("file://%s", tufRoot)
+	_, err = remoteFromMirror(mirror)
+	if err != nil {
+		t.Fatalf("unexpected error with GCS mirror: %v", err)
+	}
+}

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -807,7 +807,7 @@ func Test_remoteFromMirror(t *testing.T) {
 
 	// test local mirror
 	tufRoot := t.TempDir()
-	os.Mkdir(fmt.Sprintf("%s/targets", tufRoot), 0750)
+	os.Mkdir(fmt.Sprintf("%s/targets", tufRoot), 0o0750)
 	mirror = fmt.Sprintf("file://%s", tufRoot)
 	_, err = remoteFromMirror(mirror)
 	if err != nil {


### PR DESCRIPTION
The mirror was reconfigured, but the URL was never reparsed, so when checking the scheme, there was a nil pointer exception. This fix simply returns early for GCS buckets.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fixed TUF root initialization with GCS bucket. This affects anyone who uses their own TUF root hosted on GCS, and specifies the GCS bucket only by name and not by HTTP path.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->