### PR TITLE
update import due to deprecation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	golang.org/x/oauth2 v0.2.0
 	golang.org/x/term v0.2.0
 	google.golang.org/api v0.103.0
-	google.golang.org/genproto v0.0.0-20221111202108-142d8a6fa32e
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/square/go-jose.v2 v2.6.0
 )
@@ -113,6 +112,7 @@ require (
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/time v0.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20221111202108-142d8a6fa32e // indirect
 	google.golang.org/grpc v1.50.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -30,8 +30,8 @@ import (
 	"time"
 
 	gcpkms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
 	"google.golang.org/api/option"
-	kmspb "google.golang.org/genproto/googleapis/cloud/kms/v1"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/jellydator/ttlcache/v2"


### PR DESCRIPTION
#### Summary
- "google.golang.org/genproto/googleapis/cloud/kms/v1" is deprecated so changing to "cloud.google.com/go/kms/apiv1/kmspb"


see https://github.com/sigstore/sigstore/actions/runs/3495896059