### PR TITLE
Move OtherName and SANS functions to s/s

### DIFF
--- a/pkg/cryptoutils/sans.go
+++ b/pkg/cryptoutils/sans.go
@@ -107,8 +107,7 @@ func UnmarshalOtherNameSAN(exts []pkix.Extension) (string, error) {
 			}
 
 			var other OtherName
-			_, err := asn1.UnmarshalWithParams(v.FullBytes, &other, "tag:0")
-			if err != nil {
+			if _, err := asn1.UnmarshalWithParams(v.FullBytes, &other, "tag:0"); err != nil {
 				return "", fmt.Errorf("could not parse requested OtherName SAN: %w", err)
 			}
 			if !other.ID.Equal(OIDOtherName) {

--- a/pkg/cryptoutils/sans.go
+++ b/pkg/cryptoutils/sans.go
@@ -23,8 +23,9 @@ import (
 )
 
 var (
+	// OIDOtherName is the OID for the OtherName SAN per RFC 5280
 	OIDOtherName = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 7}
-	// OID for Subject Alternative Name
+	// SANOID is the OID for Subject Alternative Name per RFC 5280
 	SANOID = asn1.ObjectIdentifier{2, 5, 29, 17}
 )
 
@@ -127,6 +128,9 @@ func UnmarshalOtherNameSAN(exts []pkix.Extension) (string, error) {
 	return otherNames[0], nil
 }
 
+// GetSubjectAlternateNames extracts all subject alternative names from
+// the certificate, including email addresses, DNS, IP addresses, URIs,
+// and OtherName SANs
 func GetSubjectAlternateNames(cert *x509.Certificate) []string {
 	sans := []string{}
 	sans = append(sans, cert.DNSNames...)

--- a/pkg/cryptoutils/sans.go
+++ b/pkg/cryptoutils/sans.go
@@ -1,0 +1,146 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutils
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+)
+
+var (
+	OIDOtherName = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 7}
+	// OID for Subject Alternative Name
+	SANOID = asn1.ObjectIdentifier{2, 5, 29, 17}
+)
+
+// OtherName describes a name related to a certificate which is not in one
+// of the standard name formats. RFC 5280, 4.2.1.6:
+//
+//	OtherName ::= SEQUENCE {
+//	     type-id    OBJECT IDENTIFIER,
+//	     value      [0] EXPLICIT ANY DEFINED BY type-id }
+//
+// OtherName for Fulcio-issued certificates only supports UTF-8 strings as values.
+type OtherName struct {
+	ID    asn1.ObjectIdentifier
+	Value string `asn1:"utf8,explicit,tag:0"`
+}
+
+// MarshalOtherNameSAN creates a Subject Alternative Name extension
+// with an OtherName sequence. RFC 5280, 4.2.1.6:
+//
+// SubjectAltName ::= GeneralNames
+// GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+// GeneralName ::= CHOICE {
+//
+//	otherName                       [0]     OtherName,
+//	... }
+func MarshalOtherNameSAN(name string, critical bool) (*pkix.Extension, error) {
+	o := OtherName{
+		ID:    OIDOtherName,
+		Value: name,
+	}
+	bytes, err := asn1.MarshalWithParams(o, "tag:0")
+	if err != nil {
+		return nil, err
+	}
+
+	sans, err := asn1.Marshal([]asn1.RawValue{{FullBytes: bytes}})
+	if err != nil {
+		return nil, err
+	}
+	return &pkix.Extension{
+		Id:       SANOID,
+		Critical: critical,
+		Value:    sans,
+	}, nil
+}
+
+// UnmarshalOtherNameSAN extracts a UTF-8 string from the OtherName
+// field in the Subject Alternative Name extension.
+func UnmarshalOtherNameSAN(exts []pkix.Extension) (string, error) {
+	var otherNames []string
+
+	for _, e := range exts {
+		if !e.Id.Equal(SANOID) {
+			continue
+		}
+
+		var seq asn1.RawValue
+		rest, err := asn1.Unmarshal(e.Value, &seq)
+		if err != nil {
+			return "", err
+		} else if len(rest) != 0 {
+			return "", fmt.Errorf("trailing data after X.509 extension")
+		}
+		if !seq.IsCompound || seq.Tag != asn1.TagSequence || seq.Class != asn1.ClassUniversal {
+			return "", asn1.StructuralError{Msg: "bad SAN sequence"}
+		}
+
+		rest = seq.Bytes
+		for len(rest) > 0 {
+			var v asn1.RawValue
+			rest, err = asn1.Unmarshal(rest, &v)
+			if err != nil {
+				return "", err
+			}
+
+			// skip all GeneralName fields except OtherName
+			if v.Tag != 0 {
+				continue
+			}
+
+			var other OtherName
+			_, err := asn1.UnmarshalWithParams(v.FullBytes, &other, "tag:0")
+			if err != nil {
+				return "", fmt.Errorf("could not parse requested OtherName SAN: %w", err)
+			}
+			if !other.ID.Equal(OIDOtherName) {
+				return "", fmt.Errorf("unexpected OID for OtherName, expected %v, got %v", OIDOtherName, other.ID)
+			}
+			otherNames = append(otherNames, other.Value)
+		}
+	}
+
+	if len(otherNames) == 0 {
+		return "", errors.New("no OtherName found")
+	}
+	if len(otherNames) != 1 {
+		return "", errors.New("expected only one OtherName")
+	}
+
+	return otherNames[0], nil
+}
+
+func GetSubjectAlternateNames(cert *x509.Certificate) []string {
+	sans := []string{}
+	sans = append(sans, cert.DNSNames...)
+	sans = append(sans, cert.EmailAddresses...)
+	for _, ip := range cert.IPAddresses {
+		sans = append(sans, ip.String())
+	}
+	for _, uri := range cert.URIs {
+		sans = append(sans, uri.String())
+	}
+	// ignore error if there's no OtherName SAN
+	otherName, _ := UnmarshalOtherNameSAN(cert.Extensions)
+	if len(otherName) > 0 {
+		sans = append(sans, otherName)
+	}
+	return sans
+}

--- a/pkg/cryptoutils/sans_test.go
+++ b/pkg/cryptoutils/sans_test.go
@@ -1,0 +1,230 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutils
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"net"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/sigstore/sigstore/test"
+)
+
+func TestMarshalAndUnmarshalOtherNameSAN(t *testing.T) {
+	otherName := "foo!example.com"
+	critical := true
+
+	ext, err := MarshalOtherNameSAN(otherName, critical)
+	if err != nil {
+		t.Fatalf("unexpected error for MarshalOtherNameSAN: %v", err)
+	}
+	if ext.Critical != critical {
+		t.Fatalf("expected extension to be critical")
+	}
+	if !ext.Id.Equal(SANOID) {
+		t.Fatalf("expected extension's OID to be SANs OID")
+	}
+	// https://lapo.it/asn1js/#MCGgHwYKKwYBBAGDvzABB6ARDA9mb28hZXhhbXBsZS5jb20
+	// 30 - Constructed sequence
+	// 21 - length of sequence
+	// A0 - Context-specific (class 2) (bits 8,7) with Constructed bit (bit 6) and 0 tag
+	// 1F - length of context-specific field (OID)
+	// 06 - OID tag
+	// 0A - length of OID
+	// 2B 06 01 04 01 83 BF 30 01 07 - OID
+	// A0 - Context-specific (class 2) with Constructed bit and 0 tag
+	//      (needed for EXPLICIT encoding, which wraps field in outer encoding)
+	// 11 - length of context-specific field (string)
+	// 0C - UTF8String tag
+	// 0F - length of string
+	// 66 6F 6F 21 65 78 61 6D 70 6C 65 2E 63 6F 6D - string
+	if hex.EncodeToString(ext.Value) != "3021a01f060a2b0601040183bf300107a0110c0f666f6f216578616d706c652e636f6d" {
+		t.Fatalf("unexpected ASN.1 encoding")
+	}
+
+	on, err := UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err != nil {
+		t.Fatalf("unexpected error for UnmarshalOtherNameSAN: %v", err)
+	}
+	if on != otherName {
+		t.Fatalf("unexpected OtherName, expected %s, got %s", otherName, on)
+	}
+}
+
+func TestUnmarshalOtherNameSANFailures(t *testing.T) {
+	var err error
+
+	// failure: no SANs extension
+	ext := &pkix.Extension{
+		Id:       asn1.ObjectIdentifier{},
+		Critical: true,
+		Value:    []byte{},
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "no OtherName found") {
+		t.Fatalf("expected error finding no OtherName, got %v", err)
+	}
+
+	// failure: bad sequence
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    []byte{},
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "sequence truncated") {
+		t.Fatalf("expected error with invalid ASN.1, got %v", err)
+	}
+
+	// failure: extra data after valid sequence
+	b, _ := hex.DecodeString("3021a01f060a2b0601040183bf300107a0110c0f666f6f216578616d706c652e636f6d" + "30")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "trailing data after X.509 extension") {
+		t.Fatalf("expected error with extra data, got %v", err)
+	}
+
+	// failure: non-universal class (Change last two bits: 30 = 00110000 => 10110000 -> B0)
+	b, _ = hex.DecodeString("B021a01f060a2b0601040183bf300107a0110c0f666f6f216578616d706c652e636f6d")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "bad SAN sequence") {
+		t.Fatalf("expected error with non-universal class, got %v", err)
+	}
+
+	// failure: not compound sequence (Change 6th bit: 30 = 00110000 => 00010000 -> 10)
+	b, _ = hex.DecodeString("1021a01f060a2b0601040183bf300107a0110c0f666f6f216578616d706c652e636f6d")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "bad SAN sequence") {
+		t.Fatalf("expected error with non-compound sequence, got %v", err)
+	}
+
+	// failure: non-sequence tag (Change lower 5 bits: 30 = 00110000 => 00100010 -> 12)
+	b, _ = hex.DecodeString("1221a01f060a2b0601040183bf300107a0110c0f666f6f216578616d706c652e636f6d")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "bad SAN sequence") {
+		t.Fatalf("expected error with non-sequence tag, got %v", err)
+	}
+
+	// failure: no GeneralName with tag=0 (Change lower 5 bits of first sequence field: 3021a01f -> 3021a11f)
+	b, _ = hex.DecodeString("3021a11f060a2b0601040183bf300108a0110c0f666f6f216578616d706c652e636f6d")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "no OtherName found") {
+		t.Fatalf("expected error with no GeneralName, got %v", err)
+	}
+
+	// failure: invalid OtherName (Change tag of UTF8String field to 1: a0110c0f -> a1110c0f)
+	b, _ = hex.DecodeString("3021a01f060a2b0601040183bf300108a1110c0f666f6f216578616d706c652e636f6d")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "could not parse requested OtherName SAN") {
+		t.Fatalf("expected error with invalid OtherName, got %v", err)
+	}
+
+	// failure: OtherName has wrong OID (2b0601040183bf300107 -> 2b0601040183bf300108)
+	b, _ = hex.DecodeString("3021a01f060a2b0601040183bf300108a0110c0f666f6f216578616d706c652e636f6d")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "unexpected OID for OtherName") {
+		t.Fatalf("expected error with wrong OID, got %v", err)
+	}
+
+	// failure: multiple OtherName fields (Increase sequence size from 0x21 -> 0x42, duplicate OtherName)
+	b, _ = hex.DecodeString("3042a01f060a2b0601040183bf300107a0110c0f666f6f216578616d706c652e636f6da01f060a2b0601040183bf300107a0110c0f666f6f216578616d706c652e636f6d")
+	ext = &pkix.Extension{
+		Id:       SANOID,
+		Critical: true,
+		Value:    b,
+	}
+	_, err = UnmarshalOtherNameSAN([]pkix.Extension{*ext})
+	if err == nil || !strings.Contains(err.Error(), "expected only one OtherName") {
+		t.Fatalf("expected error with multiple OtherName fields, got %v", err)
+	}
+}
+
+func TestGetSubjectAltnernativeNames(t *testing.T) {
+	rootCert, rootKey, _ := test.GenerateRootCa()
+	subCert, subKey, _ := test.GenerateSubordinateCa(rootCert, rootKey)
+
+	// generate with OtherName, which will override other SANs
+	ext, err := MarshalOtherNameSAN("subject-othername", true)
+	if err != nil {
+		t.Fatalf("error marshalling SANs: %v", err)
+	}
+	exts := []pkix.Extension{*ext}
+	leafCert, _, _ := test.GenerateLeafCert("unused", "oidc-issuer", subCert, subKey, exts...)
+
+	sans := GetSubjectAlternateNames(leafCert)
+	if len(sans) != 1 {
+		t.Fatalf("expected 1 SAN field, got %d", len(sans))
+	}
+	if sans[0] != "subject-othername" {
+		t.Fatalf("unexpected OtherName SAN value")
+	}
+
+	// generate with all other SANs
+	leafCert, _, _ = test.GenerateLeafCertWithSubjectAlternateNames([]string{"subject-dns"}, []string{"subject-email"}, []net.IP{{1, 2, 3, 4}}, []*url.URL{{Path: "testURL"}}, "oidc-issuer", subCert, subKey)
+	sans = GetSubjectAlternateNames(leafCert)
+	if len(sans) != 4 {
+		t.Fatalf("expected 1 SAN field, got %d", len(sans))
+	}
+	if sans[0] != "subject-dns" {
+		t.Fatalf("unexpected DNS SAN value")
+	}
+	if sans[1] != "subject-email" {
+		t.Fatalf("unexpected email SAN value")
+	}
+	if sans[2] != "1.2.3.4" {
+		t.Fatalf("unexpected IP SAN value")
+	}
+	if sans[3] != "testURL" {
+		t.Fatalf("unexpected URL SAN value")
+	}
+}

--- a/test/cert_utils.go
+++ b/test/cert_utils.go
@@ -56,11 +56,7 @@ func createCertificate(template, parent *x509.Certificate, pub interface{}, priv
 		return nil, err
 	}
 
-	cert, err := x509.ParseCertificate(certBytes)
-	if err != nil {
-		return nil, err
-	}
-	return cert, nil
+	return x509.ParseCertificate(certBytes)
 }
 
 // GenerateRootCa generates a test root CA

--- a/test/cert_utils.go
+++ b/test/cert_utils.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package test contains test utilities
 package test
 
 import (
@@ -40,16 +41,16 @@ subs := x509.NewCertPool()
 roots.AddCert(rootCert)
 subs.AddCert(subCert)
 opts := x509.VerifyOptions{
-	Roots:         roots,
-	Intermediates: subs,
-	KeyUsages: []x509.ExtKeyUsage{
-		x509.ExtKeyUsageCodeSigning,
-	},
+        Roots:         roots,
+        Intermediates: subs,
+        KeyUsages: []x509.ExtKeyUsage{
+                x509.ExtKeyUsageCodeSigning,
+        },
 }
 _, err := leafCert.Verify(opts)
 */
 
-func createCertificate(template *x509.Certificate, parent *x509.Certificate, pub interface{}, priv crypto.Signer) (*x509.Certificate, error) {
+func createCertificate(template, parent *x509.Certificate, pub interface{}, priv crypto.Signer) (*x509.Certificate, error) {
 	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, pub, priv)
 	if err != nil {
 		return nil, err
@@ -62,6 +63,7 @@ func createCertificate(template *x509.Certificate, parent *x509.Certificate, pub
 	return cert, nil
 }
 
+// GenerateRootCa generates a test root CA
 func GenerateRootCa() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	rootTemplate := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
@@ -89,6 +91,7 @@ func GenerateRootCa() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	return cert, priv, nil
 }
 
+// GenerateSubordinateCa generates a test intermediate CA
 func GenerateSubordinateCa(rootTemplate *x509.Certificate, rootPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	subTemplate := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
@@ -117,7 +120,8 @@ func GenerateSubordinateCa(rootTemplate *x509.Certificate, rootPriv crypto.Signe
 	return cert, priv, nil
 }
 
-func GenerateLeafCert(subject string, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer, exts ...pkix.Extension) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+// GenerateLeafCert generates a test leaf certificate
+func GenerateLeafCert(subject, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer, exts ...pkix.Extension) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	exts = append(exts, pkix.Extension{
 		// OID for OIDC Issuer extension
 		Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1},
@@ -148,7 +152,8 @@ func GenerateLeafCert(subject string, oidcIssuer string, parentTemplate *x509.Ce
 	return cert, priv, nil
 }
 
-func GenerateLeafCertWithSubjectAlternateNames(dnsNames []string, emailAddresses []string, ipAddresses []net.IP, uris []*url.URL, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+// GenerateLeafCertWithSubjectAlternateNames generates a test leaf certificate with the specified SANs
+func GenerateLeafCertWithSubjectAlternateNames(dnsNames, emailAddresses []string, ipAddresses []net.IP, uris []*url.URL, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
 	certTemplate := &x509.Certificate{
 		SerialNumber:   big.NewInt(1),
 		EmailAddresses: emailAddresses,

--- a/test/cert_utils.go
+++ b/test/cert_utils.go
@@ -1,0 +1,182 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"net"
+	"net/url"
+	"time"
+)
+
+/*
+To use:
+
+rootCert, rootKey, _ := GenerateRootCa()
+subCert, subKey, _ := GenerateSubordinateCa(rootCert, rootKey)
+leafCert, _, _ := GenerateLeafCert("subject", "oidc-issuer", subCert, subKey)
+
+roots := x509.NewCertPool()
+subs := x509.NewCertPool()
+roots.AddCert(rootCert)
+subs.AddCert(subCert)
+opts := x509.VerifyOptions{
+	Roots:         roots,
+	Intermediates: subs,
+	KeyUsages: []x509.ExtKeyUsage{
+		x509.ExtKeyUsageCodeSigning,
+	},
+}
+_, err := leafCert.Verify(opts)
+*/
+
+func createCertificate(template *x509.Certificate, parent *x509.Certificate, pub interface{}, priv crypto.Signer) (*x509.Certificate, error) {
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, parent, pub, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, err
+	}
+	return cert, nil
+}
+
+func GenerateRootCa() (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	rootTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   "sigstore",
+			Organization: []string{"sigstore.dev"},
+		},
+		NotBefore:             time.Now().Add(-5 * time.Hour),
+		NotAfter:              time.Now().Add(5 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := createCertificate(rootTemplate, rootTemplate, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, priv, nil
+}
+
+func GenerateSubordinateCa(rootTemplate *x509.Certificate, rootPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	subTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   "sigstore-sub",
+			Organization: []string{"sigstore.dev"},
+		},
+		NotBefore:             time.Now().Add(-2 * time.Minute),
+		NotAfter:              time.Now().Add(2 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := createCertificate(subTemplate, rootTemplate, &priv.PublicKey, rootPriv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, priv, nil
+}
+
+func GenerateLeafCert(subject string, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer, exts ...pkix.Extension) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	exts = append(exts, pkix.Extension{
+		// OID for OIDC Issuer extension
+		Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1},
+		Critical: false,
+		Value:    []byte(oidcIssuer),
+	})
+	certTemplate := &x509.Certificate{
+		SerialNumber:    big.NewInt(1),
+		EmailAddresses:  []string{subject},
+		NotBefore:       time.Now().Add(-1 * time.Minute),
+		NotAfter:        time.Now().Add(time.Hour),
+		KeyUsage:        x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:     []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		IsCA:            false,
+		ExtraExtensions: exts,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := createCertificate(certTemplate, parentTemplate, &priv.PublicKey, parentPriv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, priv, nil
+}
+
+func GenerateLeafCertWithSubjectAlternateNames(dnsNames []string, emailAddresses []string, ipAddresses []net.IP, uris []*url.URL, oidcIssuer string, parentTemplate *x509.Certificate, parentPriv crypto.Signer) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	certTemplate := &x509.Certificate{
+		SerialNumber:   big.NewInt(1),
+		EmailAddresses: emailAddresses,
+		DNSNames:       dnsNames,
+		IPAddresses:    ipAddresses,
+		URIs:           uris,
+		NotBefore:      time.Now().Add(-1 * time.Minute),
+		NotAfter:       time.Now().Add(time.Hour),
+		KeyUsage:       x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+		IsCA:           false,
+		ExtraExtensions: []pkix.Extension{{
+			// OID for OIDC Issuer extension
+			Id:       asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1},
+			Critical: false,
+			Value:    []byte(oidcIssuer),
+		}},
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	cert, err := createCertificate(certTemplate, parentTemplate, &priv.PublicKey, parentPriv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cert, priv, nil
+}


### PR DESCRIPTION
These were used by both Cosign and Fulcio, and will now be used by Rekor, so they should be in the shared library.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->