### PR TITLE
Update Azure KMS client to handle HSM backed keys

### DIFF
--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -49,8 +49,8 @@ func init() {
 type kvClient interface {
 	CreateKey(ctx context.Context, vaultBaseURL, keyName string, parameters keyvault.KeyCreateParameters) (result keyvault.KeyBundle, err error)
 	GetKey(ctx context.Context, vaultBaseURL, keyName, keyVersion string) (result keyvault.KeyBundle, err error)
-	Sign(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error)
-	Verify(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error)
+	Sign(ctx context.Context, vaultBaseURL, keyName, keyVersion string, parameters keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error)
+	Verify(ctx context.Context, vaultBaseURL, keyName, keyVersion string, parameters keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error)
 }
 
 type azureVaultClient struct {

--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -226,10 +226,10 @@ func (a *azureVaultClient) fetchPublicKey(ctx context.Context) (crypto.PublicKey
 	keyType := string(key.Kty)
 
 	// Azure Key Vault allows keys to be stored in either default Key Vault storage
-	// or in managed HSMs. If the key is stored in a HSM, the key type is suffixed 
-	// with "-HSM". Since this suffix is specific to Azure Key Vault, it needs 
+	// or in managed HSMs. If the key is stored in a HSM, the key type is suffixed
+	// with "-HSM". Since this suffix is specific to Azure Key Vault, it needs
 	// be stripped from the key type before attempting to represent the key
-	// with a go-jose/JSONWebKey struct. 
+	// with a go-jose/JSONWebKey struct.
 	if strings.HasSuffix(keyType, "-HSM") {
 		split := strings.Split(keyType, "-HSM")
 		// since we split on the suffix, there should be only two elements

--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -46,8 +46,15 @@ func init() {
 	})
 }
 
+type kvClient interface {
+	CreateKey(ctx context.Context, vaultBaseURL, keyName string, parameters keyvault.KeyCreateParameters) (result keyvault.KeyBundle, err error)
+	GetKey(ctx context.Context, vaultBaseURL, keyName, keyVersion string) (result keyvault.KeyBundle, err error)
+	Sign(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error)
+	Verify(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error)
+}
+
 type azureVaultClient struct {
-	client    *keyvault.BaseClient
+	client    kvClient
 	keyCache  *ttlcache.Cache
 	vaultURL  string
 	vaultName string
@@ -210,12 +217,28 @@ func (a *azureVaultClient) keyCacheLoaderFunction(key string) (data interface{},
 }
 
 func (a *azureVaultClient) fetchPublicKey(ctx context.Context) (crypto.PublicKey, error) {
-	key, err := a.getKey(ctx)
+	keyBundle, err := a.getKey(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("public key: %w", err)
 	}
 
-	jwkJSON, err := json.Marshal(*key.Key)
+	key := keyBundle.Key
+	keyType := string(key.Kty)
+
+	// Azure Key Vault allows keys to be stored in either default Key Vault storage
+	// or in managed HSMs. If the key is stored in a HSM, the key type is suffixed 
+	// with "-HSM". Since this suffix is specific to Azure Key Vault, it needs 
+	// be stripped from the key type before attempting to represent the key
+	// with a go-jose/JSONWebKey struct. 
+	if strings.HasSuffix(keyType, "-HSM") {
+		split := strings.Split(keyType, "-HSM")
+		// since we split on the suffix, there should be only two elements
+		// the first element should contain the key type without the -HSM suffix
+		newKeyType := split[0]
+		key.Kty = keyvault.JSONWebKeyType(newKeyType)
+	}
+
+	jwkJSON, err := json.Marshal(*key)
 	if err != nil {
 		return nil, fmt.Errorf("encoding the jsonWebKey: %w", err)
 	}

--- a/pkg/signature/kms/azure/client_test.go
+++ b/pkg/signature/kms/azure/client_test.go
@@ -16,9 +16,147 @@
 package azure
 
 import (
+	"context"
+	"crypto/elliptic"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
 )
+
+type testKVClient struct {
+	key keyvault.JSONWebKey
+}
+
+func (c *testKVClient) CreateKey(ctx context.Context, vaultBaseURL string, keyName string, parameters keyvault.KeyCreateParameters) (result keyvault.KeyBundle, err error) {
+	key, err := generatePublicKey("EC")
+	if err != nil {
+		return result, err
+	}
+	c.key = key
+
+	result.Key = &key
+	return result, nil
+}
+
+func (c *testKVClient) GetKey(ctx context.Context, vaultBaseURL, keyName, keyVersion string) (result keyvault.KeyBundle, err error) {
+	result.Key = &c.key
+
+	return result, nil
+}
+
+func (c *testKVClient) Sign(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error) {
+	return result, nil
+}
+
+func (c *testKVClient) Verify(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error) {
+	return result, nil
+}
+
+func generatePublicKey(azureKeyType string) (keyvault.JSONWebKey, error) {
+	keyOps := []string{"sign","verify"}
+    kid := "https://honk-vault.vault.azure.net/keys/honk-key/abc123"
+
+	key := keyvault.JSONWebKey{
+		Kid: &kid,
+		Kty: keyvault.JSONWebKeyType(azureKeyType),
+		Crv: "P-256",
+		KeyOps: &keyOps,
+	}
+
+	if strings.HasPrefix(azureKeyType, "EC") {
+		privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return keyvault.JSONWebKey{}, err
+		}
+
+		ecdsaPub, ok := privKey.Public().(*ecdsa.PublicKey)
+		if !ok {
+			return keyvault.JSONWebKey{}, fmt.Errorf("failed to cast public key to esdsa public key")
+		}
+
+		xString := base64.RawURLEncoding.EncodeToString(ecdsaPub.X.Bytes())
+		key.X = &xString
+		
+		yString := base64.RawURLEncoding.EncodeToString(ecdsaPub.Y.Bytes())
+		key.Y = &yString
+
+		return key, nil
+	} else if strings.HasPrefix(azureKeyType, "RSA") {
+		privKey, err := rsa.GenerateKey(rand.Reader, 256)
+		if err != nil {
+			return keyvault.JSONWebKey{}, err
+		}
+
+		rsaPub, ok := privKey.Public().(*rsa.PublicKey)
+		if !ok {
+			return keyvault.JSONWebKey{}, fmt.Errorf("failed to cast public key to rsa public key")
+		}
+
+		nString := base64.RawURLEncoding.EncodeToString(rsaPub.N.Bytes())
+		key.N = &nString
+
+		eString := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprint(rsaPub.E)))
+		key.E = &eString
+
+		return key, nil
+	} else {
+		return keyvault.JSONWebKey{}, fmt.Errorf("invalid key type passed: %s", azureKeyType)
+	}
+	return keyvault.JSONWebKey{}, nil
+}
+
+func TestAzureVaultClientFetchPublicKey(t *testing.T) {
+	type test struct {
+		azureKeyType string
+		expectSuccess bool
+	}
+
+	tests := []test{
+		{
+			azureKeyType: "EC",
+			expectSuccess: true,
+		},
+		{
+			azureKeyType: "EC-HSM",
+			expectSuccess: true,
+		},
+		{
+			azureKeyType: "RSA",
+			expectSuccess: true,
+		},
+		{
+			azureKeyType: "RSA-HSM",
+			expectSuccess: true,
+		},
+	}
+
+	for _, tc := range tests {
+		key, err := generatePublicKey(tc.azureKeyType)
+		if err != nil {
+			t.Fatalf("unexpected error while generating public key for testing: %v", err)
+		}
+
+		kvClient := testKVClient{key: key}
+		client := azureVaultClient{
+			client:    &kvClient,
+		}
+
+		_, err = client.fetchPublicKey(context.Background())
+		if err != nil && tc.expectSuccess {
+			t.Fatalf("expected error to be nil, actual value: %v", err)
+		}
+		if err == nil && !tc.expectSuccess {
+			t.Fatal("expected error not to be nil")
+		}
+	}
+}
 
 func TestGetAuthenticationMethod(t *testing.T) {
 	clearEnv := map[string]string{

--- a/pkg/signature/kms/azure/client_test.go
+++ b/pkg/signature/kms/azure/client_test.go
@@ -34,7 +34,7 @@ type testKVClient struct {
 	key keyvault.JSONWebKey
 }
 
-func (c *testKVClient) CreateKey(ctx context.Context, vaultBaseURL string, keyName string, parameters keyvault.KeyCreateParameters) (result keyvault.KeyBundle, err error) {
+func (c *testKVClient) CreateKey(ctx context.Context, vaultBaseURL, keyName string, parameters keyvault.KeyCreateParameters) (result keyvault.KeyBundle, err error) {
 	key, err := generatePublicKey("EC")
 	if err != nil {
 		return result, err
@@ -51,11 +51,11 @@ func (c *testKVClient) GetKey(ctx context.Context, vaultBaseURL, keyName, keyVer
 	return result, nil
 }
 
-func (c *testKVClient) Sign(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error) {
+func (c *testKVClient) Sign(ctx context.Context, vaultBaseURL, keyName, keyVersion string, parameters keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error) {
 	return result, nil
 }
 
-func (c *testKVClient) Verify(ctx context.Context, vaultBaseURL string, keyName string, keyVersion string, parameters keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error) {
+func (c *testKVClient) Verify(ctx context.Context, vaultBaseURL, keyName, keyVersion string, parameters keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error) {
 	return result, nil
 }
 

--- a/pkg/signature/kms/azure/client_test.go
+++ b/pkg/signature/kms/azure/client_test.go
@@ -17,8 +17,8 @@ package azure
 
 import (
 	"context"
-	"crypto/elliptic"
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
@@ -60,13 +60,13 @@ func (c *testKVClient) Verify(ctx context.Context, vaultBaseURL string, keyName 
 }
 
 func generatePublicKey(azureKeyType string) (keyvault.JSONWebKey, error) {
-	keyOps := []string{"sign","verify"}
-    kid := "https://honk-vault.vault.azure.net/keys/honk-key/abc123"
+	keyOps := []string{"sign", "verify"}
+	kid := "https://honk-vault.vault.azure.net/keys/honk-key/abc123"
 
 	key := keyvault.JSONWebKey{
-		Kid: &kid,
-		Kty: keyvault.JSONWebKeyType(azureKeyType),
-		Crv: "P-256",
+		Kid:    &kid,
+		Kty:    keyvault.JSONWebKeyType(azureKeyType),
+		Crv:    "P-256",
 		KeyOps: &keyOps,
 	}
 
@@ -87,7 +87,7 @@ func generatePublicKey(azureKeyType string) (keyvault.JSONWebKey, error) {
 
 		xString := base64.RawURLEncoding.EncodeToString(ecdsaPub.X.Bytes())
 		key.X = &xString
-		
+
 		yString := base64.RawURLEncoding.EncodeToString(ecdsaPub.Y.Bytes())
 		key.Y = &yString
 
@@ -116,25 +116,25 @@ func generatePublicKey(azureKeyType string) (keyvault.JSONWebKey, error) {
 
 func TestAzureVaultClientFetchPublicKey(t *testing.T) {
 	type test struct {
-		azureKeyType string
+		azureKeyType  string
 		expectSuccess bool
 	}
 
 	tests := []test{
 		{
-			azureKeyType: "EC",
+			azureKeyType:  "EC",
 			expectSuccess: true,
 		},
 		{
-			azureKeyType: "EC-HSM",
+			azureKeyType:  "EC-HSM",
 			expectSuccess: true,
 		},
 		{
-			azureKeyType: "RSA",
+			azureKeyType:  "RSA",
 			expectSuccess: true,
 		},
 		{
-			azureKeyType: "RSA-HSM",
+			azureKeyType:  "RSA-HSM",
 			expectSuccess: true,
 		},
 	}
@@ -147,7 +147,7 @@ func TestAzureVaultClientFetchPublicKey(t *testing.T) {
 
 		kvClient := testKVClient{key: key}
 		client := azureVaultClient{
-			client:    &kvClient,
+			client: &kvClient,
 		}
 
 		_, err = client.fetchPublicKey(context.Background())

--- a/pkg/signature/kms/azure/signer.go
+++ b/pkg/signature/kms/azure/signer.go
@@ -50,7 +50,7 @@ type SignerVerifier struct {
 	client     *azureVaultClient
 }
 
-// LoadSignerVerifier generates signatures using the specified key object in GCP KMS and hash algorithm.
+// LoadSignerVerifier generates signatures using the specified key in Azure Key Vault and hash algorithm.
 //
 // It also can verify signatures locally using the public key. hashFunc must not be crypto.Hash(0).
 func LoadSignerVerifier(defaultCtx context.Context, referenceStr string, hashFunc crypto.Hash) (*SignerVerifier, error) {
@@ -68,13 +68,13 @@ func LoadSignerVerifier(defaultCtx context.Context, referenceStr string, hashFun
 	case 0, crypto.SHA224, crypto.SHA256, crypto.SHA384, crypto.SHA512:
 		a.hashFunc = hashFunc
 	default:
-		return nil, errors.New("hash function not supported by Hashivault")
+		return nil, errors.New("hash function not supported by Azure Key Vault")
 	}
 
 	return a, nil
 }
 
-// SignMessage signs the provided message using GCP KMS. If the message is provided,
+// SignMessage signs the provided message using Azure Key Vault. If the message is provided,
 // this method will compute the digest according to the hash function specified
 // when the Signer was created.
 //
@@ -204,13 +204,13 @@ func (c cryptoSignerWrapper) Sign(_ io.Reader, digest []byte, opts crypto.Signer
 	if opts != nil {
 		hashFunc = opts.HashFunc()
 	}
-	gcpOptions := []signature.SignOption{
+	azOptions := []signature.SignOption{
 		options.WithContext(c.ctx),
 		options.WithDigest(digest),
 		options.WithCryptoSignerOpts(hashFunc),
 	}
 
-	return c.sv.SignMessage(nil, gcpOptions...)
+	return c.sv.SignMessage(nil, azOptions...)
 }
 
 // CryptoSigner returns a crypto.Signer object that uses the underlying SignerVerifier, along with a crypto.SignerOpts object


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes https://github.com/sigstore/sigstore/issues/849

This adds support for handling HSM backed keys. Currently when the Azure KMS client tries to fetch and parse a key stored in Key Vault, it does not handle keys stored in HSMs. HSM backed keys have key types suffixed with "-HSM". This breaks when the client to tries to convert the key to a `go-jose.JSONWebKey` instance.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->