### PR TITLE
Allow Initialize/NewFromEnv to reinitialize metadata if timestamp expired

### DIFF
--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -693,7 +693,7 @@ func updateTufRepo(t *testing.T, td string, r *tuf.Repo, targetData string) {
 	}
 }
 
-func TestConcurrentAccess(t *testing.T) {
+func TestConcurrentAccessNewFromEnv(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < 20; i++ {
@@ -706,6 +706,24 @@ func TestConcurrentAccess(t *testing.T) {
 			}
 			if tufObj == nil {
 				t.Error("Got back nil tufObj")
+			}
+			time.Sleep(1 * time.Second)
+		}()
+	}
+	wg.Wait()
+	resetForTests()
+}
+
+func TestConcurrentAccessInitialize(t *testing.T) {
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := Initialize(context.Background(), DefaultRemoteRoot, nil)
+			if err != nil {
+				t.Errorf("Failed to construct NewFromEnv: %s", err)
 			}
 			time.Sleep(1 * time.Second)
 		}()


### PR DESCRIPTION
This changes Initialize/NewFromEnv to always check if the timestamp is expired, while still locking access to the TUF object.

Ref: https://github.com/sigstore/public-good-instance/issues/1161

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->