### PR TITLE
use provided context when signing and verifying via DSSE adapters

### DIFF
--- a/pkg/signature/dsse/adapters.go
+++ b/pkg/signature/dsse/adapters.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 // SignerAdapter wraps a `sigstore/signature.Signer`, making it compatible with `go-securesystemslib/dsse.Signer`.
@@ -35,11 +36,11 @@ type SignerAdapter struct {
 
 // Sign implements `go-securesystemslib/dsse.Signer`
 func (a *SignerAdapter) Sign(ctx context.Context, data []byte) ([]byte, error) {
-	return a.SignatureSigner.SignMessage(bytes.NewReader(data), a.Opts...)
+	return a.SignatureSigner.SignMessage(bytes.NewReader(data), append(a.Opts, options.WithContext(ctx))...)
 }
 
 // Verify disabled `go-securesystemslib/dsse.Verifier`
-func (a *SignerAdapter) Verify(ctx context.Context, data, sig []byte) error {
+func (a *SignerAdapter) Verify(_ context.Context, _, _ []byte) error {
 	return errors.New("Verify disabled")
 }
 
@@ -62,7 +63,7 @@ type VerifierAdapter struct {
 
 // Verify implements `go-securesystemslib/dsse.Verifier`
 func (a *VerifierAdapter) Verify(ctx context.Context, data, sig []byte) error {
-	return a.SignatureVerifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data))
+	return a.SignatureVerifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data), options.WithContext(ctx))
 }
 
 // Public implements `go-securesystemslib/dsse.Verifier`

--- a/pkg/signature/dsse/adapters_test.go
+++ b/pkg/signature/dsse/adapters_test.go
@@ -1,0 +1,32 @@
+//
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dsse
+
+import (
+	"testing"
+
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+)
+
+// TestImplementDSSESigner doesn't functionally test anything, but will fail to compile if the interface is not implemented
+func TestImplementsDSSESigner(t *testing.T) {
+	var _ dsse.Signer = &SignerAdapter{}
+}
+
+// TestImplementDSSEVerifier doesn't functionally test anything, but will fail to compile if the interface is not implemented
+func TestImplementsDSSEVerifier(t *testing.T) {
+	var _ dsse.Verifier = &VerifierAdapter{}
+}


### PR DESCRIPTION
#### Summary
https://github.com/secure-systems-lab/go-securesystemslib/commit/60bd7fdd1b0d044e01ec9692967490243bef67c3 added the `ctx` parameters during signing and verification - this PR ensures that they are used, as well as adding unit testing to ensure that the interfaces are actually correctly implemented.

#### Release Note

* `context.Context` is now correctly used during signing and verification of DSSE envelopes