### PR TITLE
swap from GCS directly to use CDN

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	// DefaultRemoteRoot is the default remote TUF root location.
-	DefaultRemoteRoot = "https://sigstore-tuf-root.storage.googleapis.com"
+	DefaultRemoteRoot = "https://tuf-repo-cdn.sigstore.dev"
 
 	// TufRootEnv is the name of the environment variable that locates an alternate local TUF root location.
 	TufRootEnv = "TUF_ROOT"

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -817,7 +817,7 @@ func Test_remoteFromMirror(t *testing.T) {
 	}
 
 	// test HTTP mirror
-	mirror = "https://tuf-root-staging.storage.googleapis.com"
+	mirror = "https://tuf-repo-cdn.sigstage.dev"
 	_, err = remoteFromMirror(mirror)
 	if err != nil {
 		t.Fatalf("unexpected error with GCS mirror: %v", err)


### PR DESCRIPTION
#### Summary
This swaps over the default URL for the sigstore TUF root to use a CDN-backed endpoint instead of hitting GCS directly.

#### Release Note
* The default sigstore TUF root is now retrieved from a CDN-backend endpoint (https://tuf-repo-cdn.sigstore.dev); the same content should be delivered as before.