### PR TITLE
map GCS HTTP endpoints to new CDN for sigstore public-good production TUF root

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -44,12 +44,12 @@ import (
 const (
 	// DefaultRemoteRoot is the default remote TUF root location.
 	DefaultRemoteRoot = "https://tuf-repo-cdn.sigstore.dev"
-	// DefaultRemoteGCSBucket is the name of the GCS bucket that holds sigstore's public good production TUF root
-	DefaultRemoteGCSBucket = "sigstore-tuf-root"
-	// DefaultRemoteRootNoCDN is the URL of the GCS HTTP endpoint for the DefaultRootGCSBucket content
-	DefaultRemoteRootNoCDN = "https://sigstore-tuf-root.storage.googleapis.com"
-	// DefaultRemoteRootNoCDNAlt is an alternate URL to the GCS HTTP endpoint for the DefaultRootGCSBucket content
-	DefaultRemoteRootNoCDNAlt = "https://storage.googleapis.com/sigstore-tuf-root"
+	// defaultRemoteGCSBucket is the name of the GCS bucket that holds sigstore's public good production TUF root
+	defaultRemoteGCSBucket = "sigstore-tuf-root"
+	// defaultRemoteRootNoCDN is the URL of the GCS HTTP endpoint for the DefaultRootGCSBucket content
+	defaultRemoteRootNoCDN = "https://sigstore-tuf-root.storage.googleapis.com"
+	// defaultRemoteRootNoCDNAlt is an alternate URL to the GCS HTTP endpoint for the DefaultRootGCSBucket content
+	defaultRemoteRootNoCDNAlt = "https://storage.googleapis.com/sigstore-tuf-root"
 
 	// TufRootEnv is the name of the environment variable that locates an alternate local TUF root location.
 	TufRootEnv = "TUF_ROOT"
@@ -87,7 +87,7 @@ type TUF struct {
 // which is a CDN fronting that DefaultRemoteGCSBucket
 func (t *TUF) Mirror() string {
 	switch t.mirror {
-	case DefaultRemoteGCSBucket, DefaultRemoteRootNoCDN, DefaultRemoteRootNoCDNAlt:
+	case defaultRemoteGCSBucket, defaultRemoteRootNoCDN, defaultRemoteRootNoCDNAlt:
 		return DefaultRemoteRoot
 	default:
 		return t.mirror

--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -44,6 +44,12 @@ import (
 const (
 	// DefaultRemoteRoot is the default remote TUF root location.
 	DefaultRemoteRoot = "https://tuf-repo-cdn.sigstore.dev"
+	// DefaultRemoteGCSBucket is the name of the GCS bucket that holds sigstore's public good production TUF root
+	DefaultRemoteGCSBucket = "sigstore-tuf-root"
+	// DefaultRemoteRootNoCDN is the URL of the GCS HTTP endpoint for the DefaultRootGCSBucket content
+	DefaultRemoteRootNoCDN = "https://sigstore-tuf-root.storage.googleapis.com"
+	// DefaultRemoteRootNoCDNAlt is an alternate URL to the GCS HTTP endpoint for the DefaultRootGCSBucket content
+	DefaultRemoteRootNoCDNAlt = "https://storage.googleapis.com/sigstore-tuf-root"
 
 	// TufRootEnv is the name of the environment variable that locates an alternate local TUF root location.
 	TufRootEnv = "TUF_ROOT"
@@ -74,6 +80,18 @@ type TUF struct {
 	remote   client.RemoteStore
 	embedded fs.FS
 	mirror   string // location of mirror
+}
+
+// Mirror returns the mirror configured; note if the object was configured with a legacy reference
+// to the GCS HTTP endpoint for sigstore's public good trust root, this will return DefaultRemoteRoot
+// which is a CDN fronting that DefaultRemoteGCSBucket
+func (t *TUF) Mirror() string {
+	switch t.mirror {
+	case DefaultRemoteGCSBucket, DefaultRemoteRootNoCDN, DefaultRemoteRootNoCDNAlt:
+		return DefaultRemoteRoot
+	default:
+		return t.mirror
+	}
 }
 
 // JSON output representing the configured root status
@@ -176,7 +194,7 @@ func (t *TUF) getRootStatus() (*RootStatus, error) {
 	}
 	status := &RootStatus{
 		Local:    local,
-		Remote:   t.mirror,
+		Remote:   t.Mirror(),
 		Metadata: make(map[string]MetadataStatus),
 		Targets:  []string{},
 	}
@@ -260,7 +278,7 @@ func initializeTUF(mirror string, root []byte, embedded fs.FS, forceUpdate bool)
 			return
 		}
 
-		t.remote, singletonTUFErr = remoteFromMirror(t.mirror)
+		t.remote, singletonTUFErr = remoteFromMirror(t.Mirror())
 		if singletonTUFErr != nil {
 			return
 		}
@@ -330,15 +348,16 @@ func NewFromEnv(_ context.Context) (*TUF, error) {
 	return initializeTUF(mirror, nil, getEmbedded(), false)
 }
 
-func Initialize(ctx context.Context, mirror string, root []byte) error {
+func Initialize(_ context.Context, mirror string, root []byte) error {
 	// Initialize the client. Force an update with remote.
-	if _, err := initializeTUF(mirror, root, getEmbedded(), true); err != nil {
+	tuf, err := initializeTUF(mirror, root, getEmbedded(), true)
+	if err != nil {
 		return err
 	}
 
 	// Store the remote for later if we are caching.
 	if !noCache() {
-		remoteInfo := &remoteCache{Mirror: mirror}
+		remoteInfo := &remoteCache{Mirror: tuf.Mirror()}
 		b, err := json.Marshal(remoteInfo)
 		if err != nil {
 			return err
@@ -437,7 +456,7 @@ func (t *TUF) updateClient() (data.TargetFiles, error) {
 			Mirror   string                    `json:"mirror"`
 			Metadata map[string]MetadataStatus `json:"metadata"`
 		}{
-			Mirror:   t.mirror,
+			Mirror:   t.Mirror(),
 			Metadata: make(map[string]MetadataStatus),
 		}
 		for _, md := range []string{"root.json", "targets.json", "snapshot.json", "timestamp.json"} {

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -93,7 +93,7 @@ func TestNewFromEnv(t *testing.T) {
 func TestLegacyURLToCDN(t *testing.T) {
 	td := t.TempDir()
 	t.Setenv("TUF_ROOT", td)
-	remoteInfo := &remoteCache{Mirror: DefaultRemoteRootNoCDN}
+	remoteInfo := &remoteCache{Mirror: defaultRemoteRootNoCDN}
 	b, err := json.Marshal(remoteInfo)
 	if err != nil {
 		t.Fatal(err)
@@ -115,7 +115,7 @@ func TestLegacyURLToCDN(t *testing.T) {
 func TestAltLegacyURLToCDN(t *testing.T) {
 	td := t.TempDir()
 	t.Setenv("TUF_ROOT", td)
-	remoteInfo := &remoteCache{Mirror: DefaultRemoteRootNoCDNAlt}
+	remoteInfo := &remoteCache{Mirror: defaultRemoteRootNoCDNAlt}
 	b, err := json.Marshal(remoteInfo)
 	if err != nil {
 		t.Fatal(err)
@@ -136,18 +136,18 @@ func TestAltLegacyURLToCDN(t *testing.T) {
 
 func TestCDNRewriteforMirror(t *testing.T) {
 	tuf := &TUF{
-		mirror: DefaultRemoteGCSBucket,
+		mirror: defaultRemoteGCSBucket,
 	}
 	if tuf.Mirror() != DefaultRemoteRoot {
 		t.Fatal("reference to default remote GCS bucket was not redirected to CDN")
 	}
 
-	tuf.mirror = DefaultRemoteRootNoCDN
+	tuf.mirror = defaultRemoteRootNoCDN
 	if tuf.Mirror() != DefaultRemoteRoot {
 		t.Fatal("reference to default remote GCS HTTP endpoint was not redirected to CDN")
 	}
 
-	tuf.mirror = DefaultRemoteRootNoCDNAlt
+	tuf.mirror = defaultRemoteRootNoCDNAlt
 	if tuf.Mirror() != DefaultRemoteRoot {
 		t.Fatal("reference to alternate remote GCS HTTP endpoint was not redirected to CDN")
 	}
@@ -156,7 +156,7 @@ func TestCDNRewriteforMirror(t *testing.T) {
 func TestLegacyBucketToCDN(t *testing.T) {
 	td := t.TempDir()
 	t.Setenv("TUF_ROOT", td)
-	remoteInfo := &remoteCache{Mirror: DefaultRemoteGCSBucket}
+	remoteInfo := &remoteCache{Mirror: defaultRemoteGCSBucket}
 	b, err := json.Marshal(remoteInfo)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -111,6 +111,7 @@ func TestLegacyURLToCDN(t *testing.T) {
 		t.Fatal("legacy prod GCS HTTP endpoint was not mapped to CDN")
 	}
 }
+
 func TestAltLegacyURLToCDN(t *testing.T) {
 	td := t.TempDir()
 	t.Setenv("TUF_ROOT", td)

--- a/pkg/tuf/client_test.go
+++ b/pkg/tuf/client_test.go
@@ -90,6 +90,69 @@ func TestNewFromEnv(t *testing.T) {
 	resetForTests()
 }
 
+func TestLegacyURLToCDN(t *testing.T) {
+	td := t.TempDir()
+	t.Setenv("TUF_ROOT", td)
+	remoteInfo := &remoteCache{Mirror: "https://sigstore-tuf-root.storage.googleapis.com"}
+	b, err := json.Marshal(remoteInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachedRemote(td), b, 0o600); err != nil {
+		t.Fatalf("storing remote: %v", err)
+	}
+
+	// First initialization, populate the cache.
+	tuf, err := NewFromEnv(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tuf.Mirror() != "https://tuf-repo-cdn.sigstore.dev" {
+		t.Fatal("legacy prod GCS HTTP endpoint was not mapped to CDN")
+	}
+}
+
+func TestCDNRewriteforMirror(t *testing.T) {
+	tuf := &TUF{
+		mirror: DefaultRemoteGCSBucket,
+	}
+	if tuf.Mirror() != DefaultRemoteRoot {
+		t.Fatal("reference to default remote GCS bucket was not redirected to CDN")
+	}
+
+	tuf.mirror = DefaultRemoteRootNoCDN
+	if tuf.Mirror() != DefaultRemoteRoot {
+		t.Fatal("reference to default remote GCS HTTP endpoint was not redirected to CDN")
+	}
+
+	tuf.mirror = DefaultRemoteRootNoCDNAlt
+	if tuf.Mirror() != DefaultRemoteRoot {
+		t.Fatal("reference to alternate remote GCS HTTP endpoint was not redirected to CDN")
+	}
+}
+
+func TestLegacyBucketToCDN(t *testing.T) {
+	td := t.TempDir()
+	t.Setenv("TUF_ROOT", td)
+	remoteInfo := &remoteCache{Mirror: "sigstore-tuf-root"}
+	b, err := json.Marshal(remoteInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachedRemote(td), b, 0o600); err != nil {
+		t.Fatalf("storing remote: %v", err)
+	}
+
+	// First initialization, populate the cache.
+	tuf, err := NewFromEnv(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tuf.Mirror() != "https://tuf-repo-cdn.sigstore.dev" {
+		t.Fatal("legacy prod bucket was not mapped to CDN")
+	}
+}
+
 func TestNoCache(t *testing.T) {
 	ctx := context.Background()
 	// Once more with NO_CACHE


### PR DESCRIPTION
This PR silently changes the use of the sigstore public-good-instance production TUF root from calling GCS's HTTP endpoints to using the newly created CDN https://tuf-repo-cdn.sigstore.dev