### PR TITLE
fix lint errors for unused args

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,4 +55,4 @@ jobs:
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         timeout-minutes: 5
         with:
-          version: v1.51
+          version: v1.52

--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -179,6 +179,6 @@ func validateEcdsaKey(pub *ecdsa.PublicKey) error {
 }
 
 // No validations currently, ED25519 supports only one key size.
-func validateEd25519Key(pub ed25519.PublicKey) error {
+func validateEd25519Key(_ ed25519.PublicKey) error {
 	return nil
 }

--- a/pkg/signature/dsse/adapters_test.go
+++ b/pkg/signature/dsse/adapters_test.go
@@ -22,11 +22,11 @@ import (
 )
 
 // TestImplementDSSESigner doesn't functionally test anything, but will fail to compile if the interface is not implemented
-func TestImplementsDSSESigner(t *testing.T) {
+func TestImplementsDSSESigner(_ *testing.T) {
 	var _ dsse.Signer = &SignerAdapter{}
 }
 
 // TestImplementDSSEVerifier doesn't functionally test anything, but will fail to compile if the interface is not implemented
-func TestImplementsDSSEVerifier(t *testing.T) {
+func TestImplementsDSSEVerifier(_ *testing.T) {
 	var _ dsse.Verifier = &VerifierAdapter{}
 }

--- a/pkg/signature/dsse/dsse.go
+++ b/pkg/signature/dsse/dsse.go
@@ -86,7 +86,7 @@ func (w *wrappedVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.P
 }
 
 // VerifySignature verifies the signature specified in an DSSE envelope
-func (w *wrappedVerifier) VerifySignature(s, _ io.Reader, opts ...signature.VerifyOption) error {
+func (w *wrappedVerifier) VerifySignature(s, _ io.Reader, _ ...signature.VerifyOption) error {
 	sig, err := io.ReadAll(s)
 	if err != nil {
 		return err

--- a/pkg/signature/dsse/multidsse.go
+++ b/pkg/signature/dsse/multidsse.go
@@ -61,12 +61,12 @@ func WrapMultiSigner(payloadType string, sL ...signature.Signer) signature.Signe
 }
 
 // PublicKey returns the public key associated with the signer
-func (wL *wrappedMultiSigner) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+func (wL *wrappedMultiSigner) PublicKey(_ ...signature.PublicKeyOption) (crypto.PublicKey, error) {
 	return nil, errors.New("not supported for multi signatures")
 }
 
 // SignMessage signs the provided stream in the reader using the DSSE encoding format
-func (wL *wrappedMultiSigner) SignMessage(r io.Reader, opts ...signature.SignOption) ([]byte, error) {
+func (wL *wrappedMultiSigner) SignMessage(r io.Reader, _ ...signature.SignOption) ([]byte, error) {
 	p, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
@@ -123,12 +123,12 @@ func WrapMultiVerifier(payloadType string, threshold int, vL ...signature.Verifi
 }
 
 // PublicKey returns the public key associated with the signer
-func (wL *wrappedMultiVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+func (wL *wrappedMultiVerifier) PublicKey(_ ...signature.PublicKeyOption) (crypto.PublicKey, error) {
 	return nil, errors.New("not supported for multi signatures")
 }
 
 // VerifySignature verifies the signature specified in an DSSE envelope
-func (wL *wrappedMultiVerifier) VerifySignature(s, _ io.Reader, opts ...signature.VerifyOption) error {
+func (wL *wrappedMultiVerifier) VerifySignature(s, _ io.Reader, _ ...signature.VerifyOption) error {
 	sig, err := io.ReadAll(s)
 	if err != nil {
 		return err

--- a/pkg/signature/kms/azure/client.go
+++ b/pkg/signature/kms/azure/client.go
@@ -202,7 +202,7 @@ func getKeysClient() (keyvault.BaseClient, error) {
 	return keyClient, nil
 }
 
-func (a *azureVaultClient) keyCacheLoaderFunction(key string) (data interface{}, ttl time.Duration, err error) {
+func (a *azureVaultClient) keyCacheLoaderFunction(_ string) (data interface{}, ttl time.Duration, err error) {
 	ttl = time.Second * 300
 	var pubKey crypto.PublicKey
 

--- a/pkg/signature/kms/azure/client_test.go
+++ b/pkg/signature/kms/azure/client_test.go
@@ -34,7 +34,7 @@ type testKVClient struct {
 	key keyvault.JSONWebKey
 }
 
-func (c *testKVClient) CreateKey(ctx context.Context, vaultBaseURL, keyName string, parameters keyvault.KeyCreateParameters) (result keyvault.KeyBundle, err error) {
+func (c *testKVClient) CreateKey(_ context.Context, _, _ string, _ keyvault.KeyCreateParameters) (result keyvault.KeyBundle, err error) {
 	key, err := generatePublicKey("EC")
 	if err != nil {
 		return result, err
@@ -45,17 +45,17 @@ func (c *testKVClient) CreateKey(ctx context.Context, vaultBaseURL, keyName stri
 	return result, nil
 }
 
-func (c *testKVClient) GetKey(ctx context.Context, vaultBaseURL, keyName, keyVersion string) (result keyvault.KeyBundle, err error) {
+func (c *testKVClient) GetKey(_ context.Context, _, _, _ string) (result keyvault.KeyBundle, err error) {
 	result.Key = &c.key
 
 	return result, nil
 }
 
-func (c *testKVClient) Sign(ctx context.Context, vaultBaseURL, keyName, keyVersion string, parameters keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error) {
+func (c *testKVClient) Sign(_ context.Context, _, _, _ string, _ keyvault.KeySignParameters) (result keyvault.KeyOperationResult, err error) {
 	return result, nil
 }
 
-func (c *testKVClient) Verify(ctx context.Context, vaultBaseURL, keyName, keyVersion string, parameters keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error) {
+func (c *testKVClient) Verify(_ context.Context, _, _, _ string, _ keyvault.KeyVerifyParameters) (result keyvault.KeyVerifyResult, err error) {
 	return result, nil
 }
 

--- a/pkg/signature/kms/azure/signer.go
+++ b/pkg/signature/kms/azure/signer.go
@@ -186,7 +186,7 @@ func (a *SignerVerifier) PublicKey(_ ...signature.PublicKeyOption) (crypto.Publi
 }
 
 // CreateKey attempts to create a new key in Vault with the specified algorithm.
-func (a *SignerVerifier) CreateKey(ctx context.Context, algorithm string) (crypto.PublicKey, error) {
+func (a *SignerVerifier) CreateKey(ctx context.Context, _ string) (crypto.PublicKey, error) {
 	return a.client.createKey(ctx)
 }
 

--- a/pkg/signature/kms/fake/signer.go
+++ b/pkg/signature/kms/fake/signer.go
@@ -94,7 +94,7 @@ func (g *SignerVerifier) VerifySignature(signature, message io.Reader, opts ...s
 }
 
 // CreateKey returns the signer's public key.
-func (g *SignerVerifier) CreateKey(etx context.Context, algorithm string) (crypto.PublicKey, error) {
+func (g *SignerVerifier) CreateKey(_ context.Context, _ string) (crypto.PublicKey, error) {
 	pub, err := g.signer.PublicKey()
 	if err != nil {
 		return nil, err

--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -157,7 +157,7 @@ type cryptoKeyVersion struct {
 // use a consistent key for cache lookups
 const cacheKey = "crypto_key_version"
 
-func (g *gcpClient) kvCacheLoaderFunction(key string) (data interface{}, ttl time.Duration, err error) {
+func (g *gcpClient) kvCacheLoaderFunction(_ string) (data interface{}, ttl time.Duration, err error) {
 	// if we're given an explicit version, cache this value forever
 	if g.version != "" {
 		ttl = time.Second * 0

--- a/pkg/signature/kms/gcp/gcp_test.go
+++ b/pkg/signature/kms/gcp/gcp_test.go
@@ -102,7 +102,7 @@ func TestParseReference(t *testing.T) {
 	}
 }
 
-func TestOptionsWork(t *testing.T) {
+func TestOptionsWork(_ *testing.T) {
 	// Check that we can pass options into LoadSignerVerifier
 	// (this is mostly a compile-time check)
 	ts := oauth2.StaticTokenSource(&oauth2.Token{})

--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -180,7 +180,7 @@ func oidcLogin(_ context.Context, address, path, role, token string) (string, er
 	return resp.TokenID()
 }
 
-func (h *hashivaultClient) keyCacheLoaderFunction(key string) (data interface{}, ttl time.Duration, err error) {
+func (h *hashivaultClient) keyCacheLoaderFunction(_ string) (data interface{}, ttl time.Duration, err error) {
 	ttl = time.Second * 300
 	var pubKey crypto.PublicKey
 	pubKey, err = h.fetchPublicKey(context.Background())

--- a/pkg/signature/options/noop.go
+++ b/pkg/signature/options/noop.go
@@ -25,25 +25,25 @@ import (
 type NoOpOptionImpl struct{}
 
 // ApplyContext is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyContext(ctx *context.Context) {}
+func (NoOpOptionImpl) ApplyContext(_ *context.Context) {}
 
 // ApplyCryptoSignerOpts is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyCryptoSignerOpts(opts *crypto.SignerOpts) {}
+func (NoOpOptionImpl) ApplyCryptoSignerOpts(_ *crypto.SignerOpts) {}
 
 // ApplyDigest is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyDigest(digest *[]byte) {}
+func (NoOpOptionImpl) ApplyDigest(_ *[]byte) {}
 
 // ApplyRand is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyRand(rand *io.Reader) {}
+func (NoOpOptionImpl) ApplyRand(_ *io.Reader) {}
 
 // ApplyRemoteVerification is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyRemoteVerification(remoteVerification *bool) {}
+func (NoOpOptionImpl) ApplyRemoteVerification(_ *bool) {}
 
 // ApplyRPCAuthOpts is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyRPCAuthOpts(opts *RPCAuth) {}
+func (NoOpOptionImpl) ApplyRPCAuthOpts(_ *RPCAuth) {}
 
 // ApplyKeyVersion is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyKeyVersion(keyVersion *string) {}
+func (NoOpOptionImpl) ApplyKeyVersion(_ *string) {}
 
 // ApplyKeyVersionUsed is a no-op required to fully implement the requisite interfaces
-func (NoOpOptionImpl) ApplyKeyVersionUsed(keyVersion **string) {}
+func (NoOpOptionImpl) ApplyKeyVersionUsed(_ **string) {}

--- a/pkg/signature/ssh/sign.go
+++ b/pkg/signature/ssh/sign.go
@@ -92,12 +92,12 @@ type Signer struct {
 }
 
 // PublicKey returns the public key for a Signer.
-func (s *Signer) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+func (s *Signer) PublicKey(_ ...signature.PublicKeyOption) (crypto.PublicKey, error) {
 	return s.signer.PublicKey(), nil
 }
 
 // SignMessage signs the supplied message.
-func (s *Signer) SignMessage(message io.Reader, opts ...signature.SignOption) ([]byte, error) {
+func (s *Signer) SignMessage(message io.Reader, _ ...signature.SignOption) ([]byte, error) {
 	b, err := io.ReadAll(message)
 	if err != nil {
 		return nil, err

--- a/pkg/signature/ssh/verify.go
+++ b/pkg/signature/ssh/verify.go
@@ -49,7 +49,7 @@ func Verify(message io.Reader, armoredSignature []byte, pubKey ssh.PublicKey) er
 var _ signature.Verifier = (*Signer)(nil)
 
 // VerifySignature verifies a suppled signature.
-func (s *Signer) VerifySignature(signature, message io.Reader, opts ...signature.VerifyOption) error {
+func (s *Signer) VerifySignature(signature, message io.Reader, _ ...signature.VerifyOption) error {
 	b, err := io.ReadAll(signature)
 	if err != nil {
 		return err


### PR DESCRIPTION
This upgrades golangci-lint to 1.52 and fixes the unused arguments it complains about.