### PR TITLE
disable HTTP connection reuse in AWS e2e tests

### DIFF
--- a/pkg/signature/kms/aws/e2e_test.go
+++ b/pkg/signature/kms/aws/e2e_test.go
@@ -23,9 +23,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/tls"
 	"fmt"
-	"net/http"
 	"os"
 	"testing"
 
@@ -46,12 +44,7 @@ type AWSSuite struct {
 
 func (suite *AWSSuite) GetProvider(key string) *SignerVerifier {
 	provider, err := LoadSignerVerifier(context.Background(), fmt.Sprintf("awskms://%s/%s", suite.endpoint, key),
-		config.WithHTTPClient(&http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, // nolint: gosec
-				DisableKeepAlives: true,
-			},
-		}), config.WithRetryMaxAttempts(0))
+		config.WithRetryMaxAttempts(5))
 	require.NoError(suite.T(), err)
 	require.NotNil(suite.T(), provider)
 	return provider

--- a/pkg/signature/kms/aws/e2e_test.go
+++ b/pkg/signature/kms/aws/e2e_test.go
@@ -48,10 +48,7 @@ type AWSSuite struct {
 type Issue1110Error struct{}
 
 func (i Issue1110Error) IsErrorRetryable(err error) aws.Ternary {
-	if err == nil {
-		return aws.UnknownTernary
-	}
-	if err.Error() == "use of closed network connection" {
+	if err != nil && err.Error() == "use of closed network connection" {
 		return aws.BoolTernary(true)
 	}
 	return aws.UnknownTernary

--- a/pkg/signature/kms/aws/e2e_test.go
+++ b/pkg/signature/kms/aws/e2e_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	awskms "github.com/aws/aws-sdk-go/service/kms"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -42,9 +44,26 @@ type AWSSuite struct {
 	endpoint string
 }
 
+// Address intermittent failure in issue #1110
+type Issue1110Error struct{}
+
+func (i Issue1110Error) IsErrorRetryable(err error) aws.Ternary {
+	if err == nil {
+		return aws.UnknownTernary
+	}
+	if err.Error() == "use of closed network connection" {
+		return aws.BoolTernary(true)
+	}
+	return aws.UnknownTernary
+}
+
 func (suite *AWSSuite) GetProvider(key string) *SignerVerifier {
 	provider, err := LoadSignerVerifier(context.Background(), fmt.Sprintf("awskms://%s/%s", suite.endpoint, key),
-		config.WithRetryMaxAttempts(5))
+		config.WithRetryer(func() aws.Retryer {
+			return retry.NewStandard(func(opts *retry.StandardOptions) {
+				opts.Retryables = append(opts.Retryables, Issue1110Error{})
+			})
+		}))
 	require.NoError(suite.T(), err)
 	require.NotNil(suite.T(), provider)
 	return provider

--- a/pkg/signature/kms/aws/e2e_test.go
+++ b/pkg/signature/kms/aws/e2e_test.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"os"
@@ -50,6 +51,7 @@ func (suite *AWSSuite) GetProvider(key string) *SignerVerifier {
 	// Disable Connection Reuse per sigstore/sigstore issue 1110
 	err = provider.client.setupClient(context.Background(), config.WithHTTPClient(&http.Client{
 		Transport: &http.Transport{
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, // nolint: gosec
 			DisableKeepAlives: true,
 		},
 	}))

--- a/pkg/signature/kms/aws/e2e_test.go
+++ b/pkg/signature/kms/aws/e2e_test.go
@@ -54,7 +54,7 @@ func (suite *AWSSuite) GetProvider(key string) *SignerVerifier {
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, // nolint: gosec
 			DisableKeepAlives: true,
 		},
-	}))
+	}), config.WithRetryMaxAttempts(0))
 	require.NoError(suite.T(), err)
 	return provider
 }

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -57,7 +57,7 @@ export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 export AWS_REGION=us-east-1
 export AWS_ENDPOINT=localhost:4566
-#export AWS_TLS_INSECURE_SKIP_VERIFY=1
+export AWS_TLS_INSECURE_SKIP_VERIFY=1
 
 export OIDC_ISSUER=http://127.0.0.1:5556/auth
 export OIDC_ID=sigstore

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -57,6 +57,7 @@ export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 export AWS_REGION=us-east-1
 export AWS_ENDPOINT=localhost:4566
+#export AWS_TLS_INSECURE_SKIP_VERIFY=1
 
 export OIDC_ISSUER=http://127.0.0.1:5556/auth
 export OIDC_ID=sigstore

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -57,7 +57,6 @@ export AWS_ACCESS_KEY_ID=test
 export AWS_SECRET_ACCESS_KEY=test
 export AWS_REGION=us-east-1
 export AWS_ENDPOINT=localhost:4566
-export AWS_TLS_INSECURE_SKIP_VERIFY=1
 
 export OIDC_ISSUER=http://127.0.0.1:5556/auth
 export OIDC_ID=sigstore


### PR DESCRIPTION
Fixes: #1110 
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
