### PR TITLE
Add `Cosign.ClaimedIdentity` API

### DIFF
--- a/pkg/signature/payload/payload.go
+++ b/pkg/signature/payload/payload.go
@@ -52,16 +52,32 @@ type Image struct {
 
 // Cosign describes a container image signed using Cosign
 type Cosign struct {
-	Image       name.Digest
-	Annotations map[string]interface{}
+	Image name.Digest
+	// ClaimedIdentity is what the signer claims the image to be; usually a registry.com/…/repo:tag, but can also use a digest instead.
+	// ALMOST ALL consumers MUST verify that ClaimedIdentity in the signature is correct given how user refers to the image;
+	// e.g. if the user asks to access a signed image example.com/repo/mysql:3.14,
+	// it is ALMOST ALWAYS necessary to validate that ClaimedIdentity = example.com/repo/mysql:3.14
+	//
+	// Considerations:
+	// - The user might refer to an image using a digest (example.com/repo/mysql@sha256:…); in that case the registry/…/repo should still match
+	// - If the image is multi-arch, ClaimedIdentity usually refers to the top-level multi-arch image index also on the per-arch images
+	//   (possibly even if ClaimedIdentity contains a digest!)
+	// - Older versions of cosign generate signatures where ClaimedIdentity only contains a registry/…/repo ; signature consumers should allow users
+	//   to determine whether such images should be accepted (and, long-term, the default SHOULD be to reject them)
+	ClaimedIdentity string
+	Annotations     map[string]interface{}
 }
 
 // SimpleContainerImage returns information about a container image in the github.com/containers/image/signature format
 func (p Cosign) SimpleContainerImage() SimpleContainerImage {
+	dockerReference := p.Image.Repository.Name()
+	if p.ClaimedIdentity != "" {
+		dockerReference = p.ClaimedIdentity
+	}
 	return SimpleContainerImage{
 		Critical: Critical{
 			Identity: Identity{
-				DockerReference: p.Image.Repository.Name(),
+				DockerReference: dockerReference,
 			},
 			Image: Image{
 				DockerManifestDigest: p.Image.DigestStr(),
@@ -98,6 +114,7 @@ func (p *Cosign) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("could not parse image digest string %q: %w", digestStr, err)
 	}
 	p.Image = digest
+	p.ClaimedIdentity = simple.Critical.Identity.DockerReference
 	p.Annotations = simple.Optional
 	return nil
 }

--- a/pkg/signature/payload/payload_test.go
+++ b/pkg/signature/payload/payload_test.go
@@ -75,6 +75,14 @@ func TestMarshalCosign(t *testing.T) {
 			},
 			expected: `{"critical":{"identity":{"docker-reference":"example.com/cosign/test/image"},"image":{"docker-manifest-digest":"sha256:d34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33f"},"type":"cosign container image signature"},"optional":{"CamelCase WithSpace":8.314,"creator":"anyone","some_struct":{"false":true,"foo":"bar","nothing":null}}}`,
 		},
+		{
+			desc: "custom identity",
+			imgPayload: Cosign{
+				Image:           mustParseDigest(t, "example.com/test/image@"+validDigest),
+				ClaimedIdentity: "docker.io/library/test:1.2.3",
+			},
+			expected: `{"critical":{"identity":{"docker-reference":"docker.io/library/test:1.2.3"},"image":{"docker-manifest-digest":"sha256:d34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33f"},"type":"cosign container image signature"},"optional":null}`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -106,14 +114,16 @@ func TestUnmarshalCosign(t *testing.T) {
 			desc:    "no claims",
 			payload: `{"critical":{"identity":{"docker-reference":"example.com/test/image"},"image":{"docker-manifest-digest":"sha256:d34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33f"},"type":"cosign container image signature"},"optional":null}`,
 			expected: Cosign{
-				Image: mustParseDigest(t, "example.com/test/image@"+validDigest),
+				Image:           mustParseDigest(t, "example.com/test/image@"+validDigest),
+				ClaimedIdentity: "example.com/test/image",
 			},
 		},
 		{
 			desc:    "arbitrary claims",
 			payload: `{"critical":{"identity":{"docker-reference":"example.com/cosign/test/image"},"image":{"docker-manifest-digest":"sha256:d34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33fd34db33f"},"type":"cosign container image signature"},"optional":{"CamelCase WithSpace":8.314,"creator":"anyone","some_struct":{"false":true,"foo":"bar","nothing":null}}}`,
 			expected: Cosign{
-				Image: mustParseDigest(t, "example.com/cosign/test/image@"+validDigest),
+				Image:           mustParseDigest(t, "example.com/cosign/test/image@"+validDigest),
+				ClaimedIdentity: "example.com/cosign/test/image",
 				Annotations: map[string]interface{}{
 					"creator": "anyone",
 					"some_struct": map[string]interface{}{


### PR DESCRIPTION
#### Summary

We now feature a `payload.Cosign.ClaimedIdentity` field which can be used to customize the `image.Critical.Identity.DockerReference`.

Refers to https://github.com/sigstore/cosign/pull/2984, https://github.com/containers/image/issues/1952
#### Release Note

* Added `payload.Cosign.ClaimedIdentity` field which can be used to customize the `image.Critical.Identity.DockerReference`.
#### Documentation

None
