### PR TITLE
have submodules specify real s/s releases

### DIFF
--- a/pkg/signature/kms/aws/go.mod
+++ b/pkg/signature/kms/aws/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.21
 	github.com/aws/aws-sdk-go-v2/service/kms v1.20.11
 	github.com/jellydator/ttlcache/v3 v3.0.1
-	github.com/sigstore/sigstore v0.0.0-00010101000000-000000000000
+	github.com/sigstore/sigstore v1.6.4
 	github.com/stretchr/testify v1.8.3
 )
 

--- a/pkg/signature/kms/azure/go.mod
+++ b/pkg/signature/kms/azure/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0
 	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/jellydator/ttlcache/v3 v3.0.1
-	github.com/sigstore/sigstore v0.0.0-00010101000000-000000000000
+	github.com/sigstore/sigstore v1.6.4
 	golang.org/x/crypto v0.9.0
 )
 

--- a/pkg/signature/kms/gcp/go.mod
+++ b/pkg/signature/kms/gcp/go.mod
@@ -7,7 +7,7 @@ go 1.18
 require (
 	cloud.google.com/go/kms v1.10.1
 	github.com/jellydator/ttlcache/v3 v3.0.1
-	github.com/sigstore/sigstore v0.0.0-00010101000000-000000000000
+	github.com/sigstore/sigstore v1.6.4
 	golang.org/x/oauth2 v0.8.0
 	google.golang.org/api v0.119.0
 	google.golang.org/protobuf v1.30.0

--- a/pkg/signature/kms/hashivault/go.mod
+++ b/pkg/signature/kms/hashivault/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/vault/api v1.9.1
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/sigstore/sigstore v0.0.0-00010101000000-000000000000
+	github.com/sigstore/sigstore v1.6.4
 	github.com/stretchr/testify v1.8.3
 )
 


### PR DESCRIPTION
https://github.com/sigstore/sigstore/pull/1115 split KMS providers into separate Go modules in this repo.

They use a `replace sigstore => ../../../` to allow the modules to build from locally cloned source, using the parent module's source for sigstore/sigstore module. Because this `replace` is used, the version of the module specified as a `require` doesn't matter, and was set to the non-existent pseudoversion `v0.0.0-00010101000000-000000000000`

This breaks down when the modules are used _outside_ the repo (e.g., in cosign), since the `replace` is not consulted, and the stand-in pseudoversion doesn't exist.

This change makes the `require` specify a real sigstore/sigstore release (the latest, currently), so they can be referenced outside of this local source tree.

@haydentherapper 