### PR TITLE
update golangci-lint to v1.53.x and add depguard rules

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -55,4 +55,4 @@ jobs:
         uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299 # v3.6.0
         timeout-minutes: 5
         with:
-          version: v1.52
+          version: v1.53

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,6 @@
 linters:
   enable:
     - asciicheck
-    - depguard
     - errcheck
     - errorlint
     - forcetypeassert

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ LDFLAGS ?=
 golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;\
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.2 ;\
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.2 ;\
 
 lint: golangci-lint ## Run golangci-lint
 	$(GOLANGCI_LINT_BIN) run -v --new-from-rev=HEAD~ ./...


### PR DESCRIPTION
#### Summary
- update golangci-lint to v1.53.x and add depguard rules