### PR TITLE
Specify hashes when comparing target meta.

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -370,15 +370,17 @@ func Initialize(_ context.Context, mirror string, root []byte) error {
 }
 
 // Checks if the testTarget matches the valid target file metadata.
-func isValidTarget(testTarget []byte, validMeta data.TargetFileMeta) bool {
-	localMeta, err := util.GenerateTargetFileMeta(bytes.NewReader(testTarget))
+func isValidTarget(testTarget []byte, validMeta data.TargetFileMeta) (bool, error) {
+	localMeta, err := util.GenerateTargetFileMeta(
+		bytes.NewReader(testTarget),
+		"sha256", "sha512")
 	if err != nil {
-		return false
+		return false, err
 	}
 	if err := util.TargetFileMetaEqual(localMeta, validMeta); err != nil {
-		return false
+		return false, err
 	}
-	return true
+	return true, nil
 }
 
 func (t *TUF) GetTarget(name string) ([]byte, error) {
@@ -394,8 +396,8 @@ func (t *TUF) GetTarget(name string) ([]byte, error) {
 		return nil, err
 	}
 
-	if !isValidTarget(targetBytes, validMeta) {
-		return nil, fmt.Errorf("cache contains invalid target; local cache may be corrupt")
+	if valid, err := isValidTarget(targetBytes, validMeta); !valid {
+		return nil, fmt.Errorf("cache contains invalid target; local cache may be corrupt: %w", err)
 	}
 
 	return targetBytes, nil
@@ -540,7 +542,7 @@ func maybeDownloadRemoteTarget(name string, meta data.TargetFileMeta, t *TUF) er
 	// If we already have the target locally, don't bother downloading from remote storage.
 	if cachedTarget, err := t.targets.Get(name); err == nil {
 		// If the target we have stored matches the meta, use that.
-		if isValidTarget(cachedTarget, meta) {
+		if valid, _ := isValidTarget(cachedTarget, meta); valid {
 			return nil
 		}
 	}
@@ -561,7 +563,7 @@ func maybeDownloadRemoteTarget(name string, meta data.TargetFileMeta, t *TUF) er
 			b = bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n"))
 		}
 
-		if isValidTarget(b, meta) {
+		if valid, _ := isValidTarget(b, meta); valid {
 			if _, err := io.Copy(&w, bytes.NewReader(b)); err != nil {
 				return fmt.Errorf("using embedded target: %w", err)
 			}


### PR DESCRIPTION
#### Summary

Before the default (sha512) hash function was the only one used when comparing hashes. This commit makes the choice explicit instead of depending on go-tuf's default vaule. Now sha256 and sha512 are recognized as valid hash functions.
Also this commit does not hide the error from go-tuf's underlying methods used to verify the target's meta.

#### Release Note
SHA256 is now a recognized hash function when verifying target metadata from a TUF repository

#### Documentation
N/A
