### PR TITLE
Handles the error in kms/hashivault

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -246,6 +246,9 @@ func (h *hashivaultClient) public() (crypto.PublicKey, error) {
 			return nil
 		},
 	)
+	if lerr != nil {
+		return nil, lerr
+	}
 
 	item := h.keyCache.Get(cacheKey, ttlcache.WithLoader[string, crypto.PublicKey](loader))
 	return item.Value(), lerr


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

* While using Tekton Chains with hashivault, if there was some misconfiguration, then it was getting panic because the error was not handled correctly

* Hence this patch handles the error before returning the value
