### PR TITLE
use the latest key version

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -313,7 +313,27 @@ func (h hashivaultClient) verify(sig, digest []byte, alg crypto.Hash, opts ...si
 			if h.keyVersion > 0 {
 				vaultDataPrefix = fmt.Sprintf("vault:v%d:", h.keyVersion)
 			} else {
-				vaultDataPrefix = vaultV1DataPrefix
+				// use hashivault client to grab the latest version of the key and use that as the prefix
+				/*				vaultDataPrefix = vaultV1DataPrefix*/
+
+				client := h.client.Logical()
+
+				path := fmt.Sprintf("/%s/keys/%s", h.transitSecretEnginePath, h.keyPath)
+
+				keyResult, err := client.Read(path)
+				if err != nil {
+					return fmt.Errorf("public key: %w", err)
+				}
+
+				if keyResult == nil {
+					return fmt.Errorf("could not read data from transit key path: %s", path)
+				}
+
+				latestVersion, hasVersion := keyResult.Data["latest_version"]
+				if !hasVersion {
+					return errors.New("failed to read transit key keys: corrupted response")
+				}
+				vaultDataPrefix = fmt.Sprintf("vault:v%s:", latestVersion.(json.Number))
 			}
 		}
 	}

--- a/pkg/signature/kms/hashivault/e2e_test.go
+++ b/pkg/signature/kms/hashivault/e2e_test.go
@@ -251,10 +251,6 @@ func (suite *VaultSuite) TestVerifySpecificKeyVersion() {
 	_, err = client.Write("/transit/keys/testverifyversion/rotate", nil)
 	assert.Nil(suite.T(), err)
 
-	// test default version again (implicitly)
-	err = provider.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data))
-	assert.Nil(suite.T(), err)
-
 	// test invalid version (0 is fine for signing, but must be >= 1 for verification)
 	err = provider.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data), options.WithKeyVersion("0"))
 	assert.NotNil(suite.T(), err)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

based on the discussions [here](https://github.com/sigstore/cosign/issues/1351), we added a code to use the latest version of the rotated key.

_P.S. If you think this is wrong please feel free to close the PR_

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
