### PR TITLE
Fixes the error handling in kms/hashivault

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -246,12 +246,17 @@ func (h *hashivaultClient) public() (crypto.PublicKey, error) {
 			return nil
 		},
 	)
+
+	item := h.keyCache.Get(cacheKey, ttlcache.WithLoader[string, crypto.PublicKey](loader))
 	if lerr != nil {
 		return nil, lerr
 	}
 
-	item := h.keyCache.Get(cacheKey, ttlcache.WithLoader[string, crypto.PublicKey](loader))
-	return item.Value(), lerr
+	if item == nil {
+		return nil, fmt.Errorf("unable to retrieve an item from the cache by the provided key")
+	}
+
+	return item.Value(), nil
 }
 
 func (h hashivaultClient) sign(digest []byte, alg crypto.Hash, opts ...signature.SignOption) ([]byte, error) {


### PR DESCRIPTION
* Previously with this patch https://github.com/sigstore/sigstore/pull/1414, 
the error was handled but the order of the error was not correct, because
while using Tekton Chains with hashivault, chains controller was getting 
paniced because the order of error handled was not correct

* Hence, with this patch, error is handled correctly and also a condition is 
added to check if the item retrieved is nil or not to avoid Tekton Chains 
controller pod crashing
