### PR TITLE
Add conditional endpoint resolver for AWS KMS

### DIFF
--- a/pkg/signature/kms/aws/client.go
+++ b/pkg/signature/kms/aws/client.go
@@ -136,9 +136,12 @@ func (a *awsClient) setupClient(ctx context.Context, opts ...func(*config.LoadOp
 	if a.endpoint != "" {
 		opts = append(opts, config.WithEndpointResolverWithOptions(
 			aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
-				return aws.Endpoint{
-					URL: "https://" + a.endpoint,
-				}, nil
+				if service == kms.ServiceID {
+					return aws.Endpoint{
+						URL: "https://" + a.endpoint,
+					}, nil
+				}
+				return aws.Endpoint{}, nil
 			}),
 		))
 	}


### PR DESCRIPTION
#### Summary

This PR introduces a conditional check within the endpoint resolver to specifically target the AWS Key Management Service (KMS). Currently, when using Security Token Service (STS), an 'unknown command' error occurred due to the STS action being inadvertently directed to the KMS endpoint defined in the user's configuration. This update ensures that KMS requests are appropriately routed to the custom endpoint specified by the user, while STS and other AWS services continue to utilise their default endpoints.

#### Release Note

Bug fix for [1175](https://github.com/sigstore/sigstore/issues/1175)

#### Documentation

N/A does not require a change to documentation. 
