### PR TITLE
Convert ED25519phSignerVerifier to the Pure version

### DIFF
--- a/pkg/signature/ed25519ph.go
+++ b/pkg/signature/ed25519ph.go
@@ -46,6 +46,16 @@ func LoadED25519phSigner(priv ed25519.PrivateKey) (*ED25519phSigner, error) {
 	}, nil
 }
 
+// ToED25519SignerVerifier creates a ED25519SignerVerifier from a ED25519phSignerVerifier
+//
+// Clients that use ED25519phSignerVerifier should use this method to get a
+// SignerVerifier that uses the same ED25519 private key, but with the Pure
+// Ed25519 algorithm. This might be necessary to interact with Fulcio, which
+// only supports the Pure Ed25519 algorithm.
+func (e ED25519phSignerVerifier) ToED25519SignerVerifier() (*ED25519SignerVerifier, error) {
+	return LoadED25519SignerVerifier(e.priv)
+}
+
 // SignMessage signs the provided message. If the message is provided,
 // this method will compute the digest according to the hash function specified
 // when the ED25519phSigner was created.

--- a/pkg/signature/signerverifier_test.go
+++ b/pkg/signature/signerverifier_test.go
@@ -17,6 +17,7 @@ package signature
 import (
 	"bytes"
 	"crypto"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"encoding/base64"
 	"testing"
@@ -52,4 +53,30 @@ func TestLoadRSAPSSSignerVerifier(t *testing.T) {
 	if err := sv.VerifySignature(bytes.NewReader(expectedSig), bytes.NewReader(message)); err != nil {
 		t.Fatalf("unexpected error verifying expected signature: %v", err)
 	}
+}
+
+func TestConvertED25519ph(t *testing.T) {
+	privateKey, err := cryptoutils.UnmarshalPEMToPrivateKey([]byte(ed25519Priv), cryptoutils.SkipPassword)
+	if err != nil {
+		t.Fatalf("unexpected error unmarshalling public key: %v", err)
+	}
+	edPriv, ok := privateKey.(ed25519.PrivateKey)
+	if !ok {
+		t.Fatalf("expected ed25519.PrivateKey")
+	}
+
+	sv, err := LoadED25519phSignerVerifier(edPriv)
+	if err != nil {
+		t.Fatalf("unexpected error creating signer/verifier: %v", err)
+	}
+
+	newSV, err := sv.ToED25519SignerVerifier()
+	if err != nil {
+		t.Fatalf("unexpected error converting to ed25519: %v", err)
+	}
+
+	message := []byte("sign me")
+	sig, _ := base64.StdEncoding.DecodeString("cnafwd8DKq2nQ564eN66ckYV8anVFGFi5vaYiQg2aal7ej/J0/OE0PPdKHLHe9wdzWRMFy5MpurRD/2cGXGLBQ==")
+	testingSigner(t, newSV, "ed25519", crypto.SHA256, message)
+	testingVerifier(t, newSV, "ed25519", crypto.SHA256, sig, message)
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
In https://github.com/sigstore/fulcio/issues/1388#issuecomment-1915809491 we agreed to just use ED25519 (Pure) in Fulcio. That means that in Cosign (maybe elsewhere?) we need to convert a ED25519phSignerVerifier to the Pure version, but for doing so we need access to the Private key, thus the new `ConvertToED25519` API.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Added `ConvertToED25519` method to `ED25519phSignerVerifier` to convert the `ED2551ph` SignerVerifier to a `ED25519` one.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
