### PR TITLE
fix: adds TSA URI for customMetadata.

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -116,6 +116,7 @@ type TargetFile struct {
 type customMetadata struct {
 	Usage  UsageKind  `json:"usage"`
 	Status StatusKind `json:"status"`
+	URI    string     `json:"uri"`
 }
 
 type sigstoreCustomMetadata struct {

--- a/pkg/tuf/usage_type.go
+++ b/pkg/tuf/usage_type.go
@@ -26,6 +26,7 @@ const (
 	Fulcio
 	Rekor
 	CTFE
+	TSA
 )
 
 var toUsageString = map[UsageKind]string{
@@ -33,6 +34,7 @@ var toUsageString = map[UsageKind]string{
 	Fulcio:       "Fulcio",
 	Rekor:        "Rekor",
 	CTFE:         "CTFE",
+	TSA:          "TSA",
 }
 
 func (u UsageKind) String() string {
@@ -57,6 +59,8 @@ func (u *UsageKind) UnmarshalText(text []byte) error {
 		*u = Rekor
 	case "ctfe":
 		*u = CTFE
+	case "tsa":
+		*u = TSA
 	default:
 		return fmt.Errorf("error while unmarshalling, UsageKind=%v not valid", string(text))
 	}

--- a/pkg/tuf/usage_type_test.go
+++ b/pkg/tuf/usage_type_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func TestMarshalUsageType(t *testing.T) {
-	usages := []UsageKind{UnknownUsage, Fulcio, Rekor, CTFE}
+	usages := []UsageKind{UnknownUsage, Fulcio, Rekor, CTFE, TSA}
 	bytes, err := json.Marshal(usages)
 	if err != nil {
 		t.Fatalf("expected no error marshalling struct, got: %v", err)
 	}
-	expected := `["Unknown","Fulcio","Rekor","CTFE"]`
+	expected := `["Unknown","Fulcio","Rekor","CTFE","TSA"]`
 	if string(bytes) != expected {
 		t.Fatalf("error while marshalling, expected: %s, got: %s", expected, bytes)
 	}
@@ -49,26 +49,26 @@ func TestMarshalInvalidUsageType(t *testing.T) {
 
 func TestUnmarshalUsageType(t *testing.T) {
 	var usages []UsageKind
-	j := json.RawMessage(`["fulcio", "rekor", "ctfe", "unknown"]`)
+	j := json.RawMessage(`["fulcio", "rekor", "ctfe", "tsa", "unknown"]`)
 	err := json.Unmarshal(j, &usages)
 	if err != nil {
 		t.Fatalf("expected no error unmarshalling struct, got: %v", err)
 	}
-	if !reflect.DeepEqual(usages, []UsageKind{Fulcio, Rekor, CTFE, UnknownUsage}) {
-		t.Fatalf("expected [Fulcio, Rekor, CTFE, UnknownUsage], got: %v", usages)
+	if !reflect.DeepEqual(usages, []UsageKind{Fulcio, Rekor, CTFE, TSA, UnknownUsage}) {
+		t.Fatalf("expected [Fulcio, Rekor, CTFE, ,TSA, UnknownUsage], got: %v", usages)
 	}
 }
 
 func TestUnmarshalUsageTypeCapitalization(t *testing.T) {
 	// Any capitalization is allowed.
 	var usages []UsageKind
-	j := json.RawMessage(`["fUlCiO", "rEkOr", "cTfE", "uNkNoWn"]`)
+	j := json.RawMessage(`["fUlCiO", "rEkOr", "cTfE", "tSa", "uNkNoWn"]`)
 	err := json.Unmarshal(j, &usages)
 	if err != nil {
 		t.Fatalf("expected no error unmarshalling struct, got: %v", err)
 	}
-	if !reflect.DeepEqual(usages, []UsageKind{Fulcio, Rekor, CTFE, UnknownUsage}) {
-		t.Fatalf("expected [Fulcio, Rekor, CTFE, UnknownUsage], got: %v", usages)
+	if !reflect.DeepEqual(usages, []UsageKind{Fulcio, Rekor, CTFE, TSA, UnknownUsage}) {
+		t.Fatalf("expected [Fulcio, Rekor, CTFE, TSA, UnknownUsage], got: %v", usages)
 	}
 }
 


### PR DESCRIPTION
closes #1645 https://github.com/sigstore/sigstore/issues/1645
#### Summary
Adds TSA to TUF custom metadata. 

Currently, when verifying a TSA timestamp w/ cosign you get the following:

**Warning** Custom metadata not configured properly for target tsa_leaf.crt.pem, skipping target
**Warning** Custom metadata not configured properly for target tsa_root.crt.pem, skipping target

This is due to a missing URI in TUF's customMetadata (e.g. [scaffolding](https://github.com/sigstore/scaffolding)) which will eventually be change to a ["trusted root" file](https://github.com/sigstore/root-signing/blob/55b61a38ebe380b133c224c4d0f827c5d3c98370/staging/repository/targets/acf0438a71de70bbf1813c908545281e0c4a1e3aafa2ce36b82c1cc24a9cce5169e9dcfe85c31bb4f662e94fdd9a686fa54fbbfccff1888e51ebd73924c12495.trusted_root.json#L1).

Further info about [this specific issue](https://sigstore.slack.com/archives/C01PZKDL4DP/p1704466042318759).

as well as @haydentherapper's [recent post on how TUF + Scaffolding's metadata will be evolving](https://sigstore.slack.com/archives/C049ALX6Q83/p1709072587850229) (e.g. ["trusted root" file](https://github.com/sigstore/root-signing/blob/55b61a38ebe380b133c224c4d0f827c5d3c98370/staging/repository/targets/acf0438a71de70bbf1813c908545281e0c4a1e3aafa2ce36b82c1cc24a9cce5169e9dcfe85c31bb4f662e94fdd9a686fa54fbbfccff1888e51ebd73924c12495.trusted_root.json#L1)).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
