### PR TITLE
tuf: Remove debug metadata downloads

### DIFF
--- a/pkg/tuf/client.go
+++ b/pkg/tuf/client.go
@@ -452,37 +452,7 @@ func (t *TUF) GetTargetsByMeta(usage UsageKind, fallbacks []string) ([]TargetFil
 func (t *TUF) updateClient() (data.TargetFiles, error) {
 	targets, err := t.client.Update()
 	if err != nil {
-		// Get some extra information for debugging. What was the state of the top-level
-		// metadata on the remote?
-		status := struct {
-			Mirror   string                    `json:"mirror"`
-			Metadata map[string]MetadataStatus `json:"metadata"`
-		}{
-			Mirror:   t.Mirror(),
-			Metadata: make(map[string]MetadataStatus),
-		}
-		for _, md := range []string{"root.json", "targets.json", "snapshot.json", "timestamp.json"} {
-			r, _, err := t.remote.GetMeta(md)
-			if err != nil {
-				// May be missing, or failed download.
-				continue
-			}
-			defer r.Close()
-			b, err := io.ReadAll(r)
-			if err != nil {
-				continue
-			}
-			mdStatus, err := getMetadataStatus(b)
-			if err != nil {
-				continue
-			}
-			status.Metadata[md] = *mdStatus
-		}
-		b, innerErr := json.MarshalIndent(status, "", "\t")
-		if innerErr != nil {
-			return nil, innerErr
-		}
-		return nil, fmt.Errorf("error updating to TUF remote mirror: %w\nremote status:%s", err, string(b))
+		return nil, fmt.Errorf("error updating to TUF remote mirror: %w", err)
 	}
 	// Success! Cache new metadata, if needed.
 	if noCache() {


### PR DESCRIPTION
The code in tuf/client.go downloads some metadata if the TUF update fails.
* The actual TUF update uses versioned URLs (e.g. "/8.root.json") but this debug code downloads different non-versioned URLS ("/root.json") so is not a very useful
* The non-versioned metadata is deprecated and likely to be removed soon

Remove the debug downloads: if better debugging info is needed, let's add that to go-tuf client update instead.

Fixes #1716 