### PR TITLE
Fix Hashicorp Vault KMS to use PKCS1 v1.5

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -276,9 +276,10 @@ func (h hashivaultClient) sign(digest []byte, alg crypto.Hash, opts ...signature
 	}
 
 	signResult, err := client.Write(fmt.Sprintf("/%s/sign/%s%s", h.transitSecretEnginePath, h.keyPath, hashString(alg)), map[string]interface{}{
-		"input":       base64.StdEncoding.Strict().EncodeToString(digest),
-		"prehashed":   alg != crypto.Hash(0),
-		"key_version": keyVersion,
+		"input":               base64.StdEncoding.Strict().EncodeToString(digest),
+		"prehashed":           alg != crypto.Hash(0),
+		"key_version":         keyVersion,
+		"signature_algorithm": "pkcs1v15",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("transit: failed to sign payload: %w", err)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
By default, Hashicorp Vault uses pss for signing. Several (if not all) sigstore components want the signature in PKCS1 v1.5 format, and since this value is not set, they fail with verification error.

Resolves: #1735

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
