### PR TITLE
Fixes issue in Device access token request

### DIFF
--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -135,8 +135,9 @@ func (d *DeviceFlowTokenGetter) deviceFlow(p *oidc.Provider, clientID, redirectU
 		// Some providers use a secret here, we don't need for sigstore oauth one so leave it off.
 		data := url.Values{
 			"grant_type":    []string{"urn:ietf:params:oauth:grant-type:device_code"},
+			"client_id":     []string{clientID},
 			"device_code":   []string{parsed.DeviceCode},
-			"scope":         []string{"openid", "email"},
+			"scope":         []string{"openid email"},
 			"code_verifier": []string{pkce.Value},
 		}
 


### PR DESCRIPTION
The fix makes the Device access token request aligned with the specification : rfc8628 

Closes #1751 

#### Summary
This fixes a bug in Device access token request, where the request always leads to the following error : `unexpected error in device flow: invalid_client` . This happens because of the missing client_id in the request. `client_id` is a required parameter as per the [specification](https://datatracker.ietf.org/doc/html/rfc8628#section-3.4)

Also the scope is incorrectly set to a slice of string :`"openid", "email"`  instead of one single string `"openid email"`. This led to following error : `unexpected error in device flow: invalid_request`

This can be tested using `--fulcio-auth-flow=device` and with an OIDC provider ( that supports device code grant , example Keycloak) configured.

#### Release Note 
NONE



