### PR TITLE
Support email_verified as a String

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Docker Build
         working-directory: ./test/e2e
-        run: docker-compose build
+        run: docker compose build
 
       - name: Integration test
         run: make test-e2e

--- a/pkg/oauth/oidc/interactive_e2e_test.go
+++ b/pkg/oauth/oidc/interactive_e2e_test.go
@@ -30,10 +30,24 @@ import (
 	"golang.org/x/oauth2"
 )
 
+type stringAsBool bool
+
+func (sb *stringAsBool) UnmarshalJSON(b []byte) error {
+	switch string(b) {
+	case "true", `"true"`, "True", `"True"`:
+		*sb = true
+	case "false", `"false"`, "False", `"False"`:
+		*sb = false
+	default:
+		return errors.New("invalid value for boolean")
+	}
+	return nil
+}
+
 type claims struct {
-	Email    string `json:"email"`
-	Verified bool   `json:"email_verified"`
-	Subject  string `json:"sub"`
+	Email    string       `json:"email"`
+	Verified stringAsBool `json:"email_verified"`
+	Subject  string       `json:"sub"`
 }
 
 func identityFromClaims(c claims) (string, error) {

--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -114,10 +114,24 @@ func OIDConnect(issuer, id, secret, redirectURL string, tg TokenGetter) (*OIDCID
 	return tg.GetIDToken(provider, config)
 }
 
+type stringAsBool bool
+
+func (sb *stringAsBool) UnmarshalJSON(b []byte) error {
+	switch string(b) {
+	case "true", `"true"`, "True", `"True"`:
+		*sb = true
+	case "false", `"false"`, "False", `"False"`:
+		*sb = false
+	default:
+		return errors.New("invalid value for boolean")
+	}
+	return nil
+}
+
 type claims struct {
-	Email    string `json:"email"`
-	Verified bool   `json:"email_verified"`
-	Subject  string `json:"sub"`
+	Email    string       `json:"email"`
+	Verified stringAsBool `json:"email_verified"`
+	Subject  string       `json:"sub"`
 }
 
 // SubjectFromToken extracts the subject claim from an OIDC Identity Token

--- a/pkg/oauthflow/flow_test.go
+++ b/pkg/oauthflow/flow_test.go
@@ -25,7 +25,9 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"unsafe"
 
+	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/go-jose/go-jose/v3"
 	"golang.org/x/oauth2"
 )
@@ -181,6 +183,86 @@ func TestStaticTokenGetter_GetIDToken(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("StaticTokenGetter.GetIDToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSubjectFromToken(t *testing.T) {
+	tests := map[string]struct {
+		Subject         string
+		Email           string
+		EmailVerified   interface{}
+		ExpectedSubject string
+		WantErr         bool
+	}{
+		`Email as subject`: {
+			Email:           "kilgore@kilgore.trout",
+			EmailVerified:   true,
+			Subject:         "foobar",
+			ExpectedSubject: "kilgore@kilgore.trout",
+			WantErr:         false,
+		},
+		`Subject as subject`: {
+			Subject:         "foobar",
+			ExpectedSubject: "foobar",
+			WantErr:         false,
+		},
+		`no email or subject`: {
+			WantErr: true,
+		},
+		`String email_verified value`: {
+			Email:           "kilgore@kilgore.trout",
+			EmailVerified:   "true",
+			ExpectedSubject: "kilgore@kilgore.trout",
+			WantErr:         false,
+		},
+		`Email not verified`: {
+			Email:         "kilgore@kilgore.trout",
+			EmailVerified: false,
+			WantErr:       true,
+		},
+		`invalid email_verified property`: {
+			Email:         "kilgore@kilgore.trout",
+			EmailVerified: "foo",
+			WantErr:       true,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			inputClaims := map[string]interface{}{
+				"email": test.Email,
+				"sub":   test.Subject,
+			}
+
+			if test.EmailVerified != nil {
+				inputClaims["email_verified"] = test.EmailVerified
+			}
+
+			claims, err := json.Marshal(inputClaims)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			token := &oidc.IDToken{}
+
+			// reflect hack because "claims" field is unexported by oidc IDToken
+			// https://github.com/coreos/go-oidc/pull/329
+			val := reflect.Indirect(reflect.ValueOf(token))
+			member := val.FieldByName("claims")
+			pointer := unsafe.Pointer(member.UnsafeAddr())
+			realPointer := (*[]byte)(pointer)
+			*realPointer = claims
+
+			subject, err := SubjectFromToken(token)
+			if err != nil {
+				if !test.WantErr {
+					t.Fatal("didn't expect error", err)
+				}
+			}
+
+			if subject != test.ExpectedSubject {
+				t.Errorf("got %v subject and expected %v", subject, test.Subject)
 			}
 		})
 	}

--- a/test/e2e/e2e-test.sh
+++ b/test/e2e/e2e-test.sh
@@ -18,7 +18,7 @@ set -ex
 
 cleanup() {
   echo "cleanup"
-  docker-compose down
+  docker compose down
 }
 
 trap cleanup ERR
@@ -27,13 +27,13 @@ export VAULT_TOKEN=testtoken
 export VAULT_ADDR=http://localhost:8200/
 
 echo "starting services"
-docker-compose config
-docker-compose up -d --build
+docker compose config
+docker compose up -d --build
 
 count=0
 
 echo -n "waiting up to 60 sec for system to start"
-until [ $(docker-compose ps vault | grep -c -e "Up" -e "running") == 1 -a $(docker-compose logs localstack | grep -c Ready) == 1 ];
+until [ $(docker compose ps vault | grep -c -e "Up" -e "running") == 1 -a $(docker compose logs localstack | grep -c Ready) == 1 ];
 do
     if [ $count -eq 12 ]; then
        echo "! timeout reached"


### PR DESCRIPTION
#### Summary

Added support for the `email_verified` property of an ID token to be either a boolean or string

Related to: https://github.com/sigstore/fulcio/pull/1744

#### Release Note

Added support for the `email_verified` property of the ID token to be either a String or Boolean

-->

#### Documentation

Added support for the `email_verified` property of the ID token to be either a String or Boolean
