### PR TITLE
Deserialize ed25519 keys from hashivault correctly

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -231,13 +231,15 @@ func (h *hashivaultClient) fetchPublicKey(_ context.Context) (crypto.PublicKey, 
 		return nil, fmt.Errorf("could not parse public key pem as string")
 	}
 	// vault returns the key type in the "name" field
-	keyType := keyMap["name"]
-	if keyType == "ed25519" {
+	if keyType := keyMap["name"]; keyType == "ed25519" {
 		// vault returns ed25519 public keys as base64 encoding of
 		// the raw bytes of the key
 		decodedPublicKey, err := base64.StdEncoding.DecodeString(strPublicKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to base64 decode ed25519 public key: %s", err)
+		}
+		if keyLen := len(decodedPublicKey); keyLen != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("decoded ed25519 public key length is %d, should be %d", keyLen, ed25519.PublicKeySize)
 		}
 		return ed25519.PublicKey(decodedPublicKey), nil
 	}

--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -19,6 +19,7 @@ package hashivault
 import (
 	"context"
 	"crypto"
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -220,17 +221,28 @@ func (h *hashivaultClient) fetchPublicKey(_ context.Context) (crypto.PublicKey, 
 		return nil, fmt.Errorf("could not parse transit key keys data as map[string]interface{}")
 	}
 
-	publicKeyPem, ok := keyMap["public_key"]
+	publicKey, ok := keyMap["public_key"]
 	if !ok {
 		return nil, errors.New("failed to read transit key keys: corrupted response")
 	}
 
-	strPublicKeyPem, ok := publicKeyPem.(string)
+	strPublicKey, ok := publicKey.(string)
 	if !ok {
 		return nil, fmt.Errorf("could not parse public key pem as string")
 	}
+	// vault returns the key type in the "name" field
+	keyType := keyMap["name"]
+	if keyType == "ed25519" {
+		// vault returns ed25519 public keys as base64 encoding of
+		// the raw bytes of the key
+		decodedPublicKey, err := base64.StdEncoding.DecodeString(strPublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to base64 decode ed25519 public key: %s", err)
+		}
+		return ed25519.PublicKey(decodedPublicKey), nil
+	}
 
-	return cryptoutils.UnmarshalPEMToPublicKey([]byte(strPublicKeyPem))
+	return cryptoutils.UnmarshalPEMToPublicKey([]byte(strPublicKey))
 }
 
 func (h *hashivaultClient) public() (crypto.PublicKey, error) {

--- a/pkg/signature/kms/hashivault/e2e_test.go
+++ b/pkg/signature/kms/hashivault/e2e_test.go
@@ -424,6 +424,22 @@ func (suite *VaultSuite) TestVerify() {
 	assert.Nil(suite.T(), err)
 }
 
+func (suite *VaultSuite) TestED25519() {
+	provider := suite.GetProvider("testverify")
+
+	key, err := provider.CreateKey(context.Background(), AlgorithmED25519)
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), key)
+
+	data := []byte("mydata")
+	sig, err := provider.SignMessage(bytes.NewReader(data))
+	assert.Nil(suite.T(), err)
+	assert.NotNil(suite.T(), sig)
+
+	err = provider.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data))
+	assert.Nil(suite.T(), err)
+}
+
 func (suite *VaultSuite) TestVerifyBadData() {
 	provider := suite.GetProvider("testverify")
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Fixes sign/verify using an ed25519 key stored in Hashicorp Vault's transit engine. Vault returns public keys in different encodings depending on the key type. In the case of ed25519, it base64 encodes the raw public key bytes.

Resolves #1810 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
