### PR TITLE
fix golangci-lint issues

### DIFF
--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -103,15 +103,15 @@ func EqualKeys(first, second crypto.PublicKey) error {
 	switch pub := first.(type) {
 	case *rsa.PublicKey:
 		if !pub.Equal(second) {
-			return fmt.Errorf(genErrMsg(first, second, "rsa"))
+			return errors.New(genErrMsg(first, second, "rsa"))
 		}
 	case *ecdsa.PublicKey:
 		if !pub.Equal(second) {
-			return fmt.Errorf(genErrMsg(first, second, "ecdsa"))
+			return errors.New(genErrMsg(first, second, "ecdsa"))
 		}
 	case ed25519.PublicKey:
 		if !pub.Equal(second) {
-			return fmt.Errorf(genErrMsg(first, second, "ed25519"))
+			return errors.New(genErrMsg(first, second, "ed25519"))
 		}
 	default:
 		return errors.New("unsupported key type")


### PR DESCRIPTION
#### Summary
Fix issues with using `fmt.Errorf` with dynamic
strings that do not contain any % format specifiers. Use `errors.New` instead.

The golangci-lint output in the trunk version is below - none with the PR change:
```bash
$ golangci-lint run --enable-only staticcheck ./...
pkg/cryptoutils/publickey.go:106:11: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			return fmt.Errorf(genErrMsg(first, second, "rsa"))
			       ^
pkg/cryptoutils/publickey.go:110:11: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			return fmt.Errorf(genErrMsg(first, second, "ecdsa"))
			       ^
pkg/cryptoutils/publickey.go:114:11: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
			return fmt.Errorf(genErrMsg(first, second, "ed25519"))
			       ^
```

#### Release Note
NONE

#### Documentation
none
