### PR TITLE
oauthflow: Add SubjectFromUnverifiedToken

### DIFF
--- a/pkg/oauthflow/flow.go
+++ b/pkg/oauthflow/flow.go
@@ -143,6 +143,16 @@ func SubjectFromToken(tok *oidc.IDToken) (string, error) {
 	return subjectFromClaims(claims)
 }
 
+// SubjectFromUnverifiedToken extracts the subject claim from the raw bytes of
+// an OIDC identity token.
+func SubjectFromUnverifiedToken(tok []byte) (string, error) {
+	claims := claims{}
+	if err := json.Unmarshal(tok, &claims); err != nil {
+		return "", err
+	}
+	return subjectFromClaims(claims)
+}
+
 func subjectFromClaims(c claims) (string, error) {
 	if c.Email != "" {
 		if !c.Verified {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR adds a SubjectFromUnverifiedToken function to accompany SubjectFromToken. Unlike SubjectFromToken which accepts a token that is verified against the issuing IDP, this function operates on the raw bytes of the token. This is useful for clients or libraries that need to know the subject of the token to sign proof of key possession over when requesting a certificate from Fulcio, but do not want to verify the token's signature as Fulcio will do so anyway.

Discussed in https://github.com/sigstore/sigstore-go/pull/283#discussion_r1735246780

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Added `SubjectFromUnverifiedToken` to extract subject claim from the unverified bytes of an identity token

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

None