### PR TITLE
fix(kms): fix CreateKey may panic when using GCP KMS

### DIFF
--- a/pkg/signature/kms/gcp/client.go
+++ b/pkg/signature/kms/gcp/client.go
@@ -415,6 +415,9 @@ func (g *gcpClient) createKeyRing(ctx context.Context) error {
 		KeyRingId: g.keyRing,
 	}
 	result, err := g.kmsClient.CreateKeyRing(ctx, createKeyRingRequest)
+	if err != nil {
+		return fmt.Errorf("creating keyring: %w", err)
+	}
 	log.Printf("Created key ring %s in GCP KMS.\n", result.GetName())
-	return err
+	return nil
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Add error check to fix CreateKey may panic when using GCP KMS

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

fix(kms): fix CreateKey may panic when using GCP KMS

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
