### PR TITLE
Add workflow to synchronize go dependencies in submodules

### DIFF
--- a/.github/workflows/sync-go-mod.yml
+++ b/.github/workflows/sync-go-mod.yml
@@ -1,0 +1,49 @@
+name: Synchronize go.mod in submodules
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+    paths:
+      - 'go.mod'
+
+jobs:
+  sync-go-mod:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.GO_MOD_SYNC_TOKEN }}
+
+      - name: Install Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+
+      - name: Synchronize go.mod in submodules
+        run: |
+          WORKDIR=$(pwd)
+          cd $WORKDIR/pkg/signature/kms/aws; go mod tidy
+          cd $WORKDIR/pkg/signature/kms/azure; go mod tidy
+          cd $WORKDIR/pkg/signature/kms/gcp; go mod tidy
+          cd $WORKDIR/pkg/signature/kms/hashivault; go mod tidy
+
+      - name: Commit and push changes
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Changes detected:"
+            git diff
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -a -s -m "Synchronize go.mod in submodules"
+            git push origin HEAD:${{ github.event.pull_request.head.ref }}
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR attempts to improve the workflow of managing Dependabot updates to this repo. The problem is that when Dependabot updates a dependency in the main module, those updates are not reflected in the "submodules" (kms providers) which includes a reference to the main module. That causes the build to fail, and one maintainer must manually run go mod tidy in the submodule and push those changes, and another maintainer must approve and merge them (as the last committer is disallowed from merging a PR). 

This PR depends on a new secret to be created `GO_MOD_SYNC_TOKEN`, which should have permission to write to the contents of this repo.

This is similar to the workflow in this PR: https://github.com/sigstore/sigstore-go/pull/314

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
