### PR TITLE
fix: set go module directive to 1.22.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,24 +16,37 @@
 name: CodeQL
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read
   security-events: write
 
 jobs:
+  go_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - name: Get Go version directive from go.mod as major.minor
+        id: list
+        run: |
+          go list -m -f 'version={{.GoVersion}}' | cut -d. -f-2 >>"${GITHUB_OUTPUT}"
+    outputs:
+      version: ${{ steps.list.outputs.version }}
   analyze:
     name: Analyze
+    needs:
+      - go_version
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ["go"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -41,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
+          go-version: "${{ needs.go_version.outputs.version }}.x"
           check-latest: true
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,35 +26,25 @@ permissions:
   security-events: write
 
 jobs:
-  go_version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
-      - name: Get Go version directive from go.mod as major.minor
-        id: list
-        run: |
-          go list -m -f 'version={{.GoVersion}}' | cut -d. -f-2 >>"${GITHUB_OUTPUT}"
-    outputs:
-      version: ${{ steps.list.outputs.version }}
   analyze:
     name: Analyze
-    needs:
-      - go_version
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
         language: ["go"]
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Get Go version directive from go.mod as major.minor
+        id: go_version
+        run: |
+          awk -F'[ .]' '/^go /{print "version=" $2 "." $3; exit}' go.mod >>"${GITHUB_OUTPUT}"
 
       - name: Set up Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: "${{ needs.go_version.outputs.version }}.x"
+          go-version: "${{ steps.go_version.outputs.version }}"
           check-latest: true
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -17,16 +17,29 @@ name: test
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 permissions:
   contents: read
 
 jobs:
+  go_version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+      - name: Get Go version directive from go.mod as major.minor
+        id: list
+        run: |
+          go list -m -f 'version={{.GoVersion}}' | cut -d. -f-2 >>"${GITHUB_OUTPUT}"
+    outputs:
+      version: ${{ steps.list.outputs.version }}
   e2e_test:
     name: e2e integration tests
+    needs:
+      - go_version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -34,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version-file: go.mod
+          go-version: "${{ needs.go_version.outputs.version }}.x"
           check-latest: true
 
       - name: Cache Modules

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -25,29 +25,21 @@ permissions:
   contents: read
 
 jobs:
-  go_version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
-      - name: Get Go version directive from go.mod as major.minor
-        id: list
-        run: |
-          go list -m -f 'version={{.GoVersion}}' | cut -d. -f-2 >>"${GITHUB_OUTPUT}"
-    outputs:
-      version: ${{ steps.list.outputs.version }}
   e2e_test:
     name: e2e integration tests
-    needs:
-      - go_version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Get Go version directive from go.mod as major.minor
+        id: go_version
+        run: |
+          awk -F'[ .]' '/^go /{print "version=" $2 "." $3; exit}' go.mod >>"${GITHUB_OUTPUT}"
+
       - name: Set up Go
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
-          go-version: "${{ needs.go_version.outputs.version }}.x"
+          go-version: "${{ steps.go_version.outputs.version }}"
           check-latest: true
 
       - name: Cache Modules

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/sigstore
 
-go 1.22.8
+go 1.22.0
 
 require (
 	github.com/coreos/go-oidc/v3 v3.11.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/sigstore/hack/tools
 
-go 1.22.7
+go 1.22.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20211123104302-8fea106b46e2

--- a/pkg/signature/kms/aws/go.mod
+++ b/pkg/signature/kms/aws/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/aws
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.22.8
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go v1.55.5

--- a/pkg/signature/kms/azure/go.mod
+++ b/pkg/signature/kms/azure/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/azure
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.22.8
+go 1.22.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.16.0

--- a/pkg/signature/kms/gcp/go.mod
+++ b/pkg/signature/kms/gcp/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/gcp
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.22.8
+go 1.22.0
 
 require (
 	cloud.google.com/go/kms v1.20.1

--- a/pkg/signature/kms/hashivault/go.mod
+++ b/pkg/signature/kms/hashivault/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/hashivault
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.22.8
+go 1.22.0
 
 require (
 	github.com/hashicorp/vault/api v1.15.0

--- a/test/fuzz/go.mod
+++ b/test/fuzz/go.mod
@@ -1,6 +1,7 @@
 module github.com/sigstore/sigstore/test/fuzz
 
-go 1.22.7
+go 1.22.0
+
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20211102141018-f7be0cbad29c
 	github.com/dvyukov/go-fuzz v0.0.0-20210914135545-4980593459a1


### PR DESCRIPTION
#### Summary

The go directive sets the minimum version of Go required to use this module. There's no need to set this to the latest semver patch version of a given Go release unless the semantics of that version of Go are required to build/test/use the module.

Notably since PR #1865 any consumers of sigstore as a library would need to bump their own go directive to 1.22.8 in order to pickup the sigstore 1.8.10 release.

Ref: https://go.dev/ref/mod#go-mod-file-go

Fixes #1879

#### Release Note

None

#### Documentation

N/A
