### PR TITLE
use ubuntu-22.04 for the e2e tests workflow 

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -27,7 +27,10 @@ permissions:
 jobs:
   e2e_test:
     name: e2e integration tests
-    runs-on: ubuntu-latest
+    # using ubuntu-22.04 because on 24.02 we are getting
+    # panic: [launcher] Failed to get the debug url: [9175:9175:0114/132426.963765:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
+    # TODO: investigate and fix the issue or try the latest ubuntu some time in the future
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "3.8"
 services:
   vault:
     build:
@@ -41,4 +40,3 @@ services:
     volumes:
       - ./dex-config.yml:/etc/dex/dex-config.yml:z
     command: ["dex", "serve", "/etc/dex/dex-config.yml"]
-


### PR DESCRIPTION
- use ubuntu-22.04 for the e2e tests workflow 
- drop obsolete version

we are getting those errors
```
panic: [launcher] Failed to get the debug url: [9175:9175:0114/132426.963765:FATAL:zygote_host_impl_linux.cc(126)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```

see https://github.com/sigstore/sigstore/actions/runs/12753677837/job/35573189089?pr=1932 as example