### PR TITLE
fix: cliplugin: return ErrorProviderNotFound when calling Get with a path

### DIFF
--- a/pkg/signature/kms/kms.go
+++ b/pkg/signature/kms/kms.go
@@ -66,7 +66,7 @@ func Get(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts .
 		}
 	}
 	sv, err := cliplugin.LoadSignerVerifier(ctx, keyResourceID, hashFunc, opts...)
-	if errors.Is(err, exec.ErrNotFound) {
+	if errors.Is(err, exec.ErrNotFound) || errors.Is(err, cliplugin.ErrorInputKeyResourceID) {
 		return nil, fmt.Errorf("%w: %w", &ProviderNotFoundError{ref: keyResourceID}, err)
 	}
 	return sv, err

--- a/pkg/signature/kms/kms.go
+++ b/pkg/signature/kms/kms.go
@@ -52,8 +52,10 @@ var providersMap = map[string]ProviderInit{}
 
 // Get returns a KMS SignerVerifier for the given resource string and hash function.
 // If no matching built-in provider is found, it will try to use the plugin system as a provider.
-// If keyResourceID doesn't match any of our hard-coded providers' schemas, or the plugin program
-// can't be found, then it returns ProviderNotFoundError.
+// It returns a ProviderNotFoundError in these situations:
+// - keyResourceID doesn't match any of our hard-coded providers' schemas,
+// - the plugin name and key ref cannot be parsed from the input keyResourceID,
+// - the plugin program, can't be found.
 // It also returns an error if initializing the SignerVerifier fails.
 func Get(ctx context.Context, keyResourceID string, hashFunc crypto.Hash, opts ...signature.RPCOption) (SignerVerifier, error) {
 	for ref, pi := range providersMap {

--- a/pkg/signature/kms/kms_test.go
+++ b/pkg/signature/kms/kms_test.go
@@ -81,7 +81,7 @@ func TestGet(t *testing.T) {
 			t.Errorf("wanted ProviderNotFoundError, got: %v", err)
 		}
 		if !errors.Is(err, cliplugin.ErrorInputKeyResourceID) {
-			t.Errorf("wanted exec.ErrNotFound, got: %v", err)
+			t.Errorf("wanted cliplugin.ErrorInputKeyResourceID, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes #1979 

**Testing**

Test against cosign

```shell
cd cosign
go mod edit -replace "github.com/sigstore/sigstore"="../sigstore"
go mod tidy
make test
```

sigstore CI tests pass.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Changes `kms.Get()` to return a `ProviderNotFoundError` when the user supplies a filepath, or an input keyResourceID that cannot be parsed by `[provider]://[key ref]`.

#### Documentation
<!--


Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

No new documentation.