### PR TITLE
Implement default signing algorithms based on the key type

### DIFF
--- a/pkg/signature/signer.go
+++ b/pkg/signature/signer.go
@@ -123,3 +123,14 @@ func LoadSignerFromPEMFileWithOpts(path string, pf cryptoutils.PassFunc, opts ..
 	}
 	return LoadSignerWithOpts(priv, opts...)
 }
+
+// LoadSignerFromPrivateKey returns a signature.Signer based on the private key.
+// Each private key has a corresponding PublicKeyDetails associated in the
+// Sigstore ecosystem, see Algorithm Registry for more details.
+func LoadSignerFromPrivateKey(privateKey crypto.PrivateKey) (Signer, error) {
+	algorithmDetails, err := GetDefaultAlgorithmDetails(privateKey)
+	if err != nil {
+		return nil, err
+	}
+	return LoadSignerWithOpts(privateKey, options.WithHash(algorithmDetails.GetHashType()), options.WithED25519ph())
+}

--- a/pkg/signature/signer.go
+++ b/pkg/signature/signer.go
@@ -124,10 +124,10 @@ func LoadSignerFromPEMFileWithOpts(path string, pf cryptoutils.PassFunc, opts ..
 	return LoadSignerWithOpts(priv, opts...)
 }
 
-// LoadSignerFromPrivateKey returns a signature.Signer based on the private key.
+// LoadDefaultSigner returns a signature.Signer based on the private key.
 // Each private key has a corresponding PublicKeyDetails associated in the
 // Sigstore ecosystem, see Algorithm Registry for more details.
-func LoadSignerFromPrivateKey(privateKey crypto.PrivateKey, opts ...LoadOption) (Signer, error) {
+func LoadDefaultSigner(privateKey crypto.PrivateKey, opts ...LoadOption) (Signer, error) {
 	signer, ok := privateKey.(crypto.Signer)
 	if !ok {
 		return nil, errors.New("private key does not implement signature.Signer")

--- a/pkg/signature/signer.go
+++ b/pkg/signature/signer.go
@@ -127,10 +127,24 @@ func LoadSignerFromPEMFileWithOpts(path string, pf cryptoutils.PassFunc, opts ..
 // LoadSignerFromPrivateKey returns a signature.Signer based on the private key.
 // Each private key has a corresponding PublicKeyDetails associated in the
 // Sigstore ecosystem, see Algorithm Registry for more details.
-func LoadSignerFromPrivateKey(privateKey crypto.PrivateKey) (Signer, error) {
-	algorithmDetails, err := GetDefaultAlgorithmDetails(privateKey)
+func LoadSignerFromPrivateKey(privateKey crypto.PrivateKey, opts ...LoadOption) (Signer, error) {
+	signer, ok := privateKey.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("private key does not implement signature.Signer")
+	}
+	algorithmDetails, err := GetDefaultAlgorithmDetails(signer.Public(), opts...)
 	if err != nil {
 		return nil, err
 	}
-	return LoadSignerWithOpts(privateKey, options.WithHash(algorithmDetails.GetHashType()), options.WithED25519ph())
+	filteredOpts := []LoadOption{options.WithHash(algorithmDetails.hashType)}
+	for _, opt := range opts {
+		var useED25519ph bool
+		var rsaPSSOptions *rsa.PSSOptions
+		opt.ApplyED25519ph(&useED25519ph)
+		opt.ApplyRSAPSS(&rsaPSSOptions)
+		if useED25519ph || rsaPSSOptions != nil {
+			filteredOpts = append(filteredOpts, opt)
+		}
+	}
+	return LoadSignerWithOpts(privateKey, filteredOpts...)
 }

--- a/pkg/signature/signer_test.go
+++ b/pkg/signature/signer_test.go
@@ -157,7 +157,7 @@ func TestLoadDefaultSigner(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			sv, err := LoadSignerFromPrivateKey(tt.key(), tt.opts...)
+			sv, err := LoadDefaultSigner(tt.key(), tt.opts...)
 			if err != nil {
 				t.Fatalf("unexpected error creating signer: %v", err)
 			}

--- a/pkg/signature/signerverifier.go
+++ b/pkg/signature/signerverifier.go
@@ -104,10 +104,10 @@ func LoadSignerVerifierFromPEMFileWithOpts(path string, pf cryptoutils.PassFunc,
 	return LoadSignerVerifierWithOpts(priv, opts...)
 }
 
-// LoadSignerVerifierFromPrivateKey returns a signature.SignerVerifier based on
+// LoadDefaultSignerVerifier returns a signature.SignerVerifier based on
 // the private key. Each private key has a corresponding PublicKeyDetails
 // associated in the Sigstore ecosystem, see Algorithm Registry for more details.
-func LoadSignerVerifierFromPrivateKey(privateKey crypto.PrivateKey, opts ...LoadOption) (SignerVerifier, error) {
+func LoadDefaultSignerVerifier(privateKey crypto.PrivateKey, opts ...LoadOption) (SignerVerifier, error) {
 	signer, ok := privateKey.(crypto.Signer)
 	if !ok {
 		return nil, errors.New("private key does not implement signature.Signer")

--- a/pkg/signature/signerverifier.go
+++ b/pkg/signature/signerverifier.go
@@ -103,3 +103,18 @@ func LoadSignerVerifierFromPEMFileWithOpts(path string, pf cryptoutils.PassFunc,
 	}
 	return LoadSignerVerifierWithOpts(priv, opts...)
 }
+
+// LoadSignerVerifierFromPrivateKey returns a signature.SignerVerifier based on
+// the private key. Each private key has a corresponding PublicKeyDetails
+// associated in the Sigstore ecosystem, see Algorithm Registry for more details.
+func LoadSignerVerifierFromPrivateKey(privateKey crypto.PrivateKey) (SignerVerifier, error) {
+	signer, ok := privateKey.(crypto.Signer)
+	if !ok {
+		return nil, errors.New("private key does not implement signature.Signer")
+	}
+	algorithmDetails, err := GetDefaultAlgorithmDetails(signer.Public())
+	if err != nil {
+		return nil, err
+	}
+	return LoadSignerVerifierWithOpts(privateKey, options.WithHash(algorithmDetails.GetHashType()), options.WithED25519ph())
+}

--- a/pkg/signature/signerverifier_test.go
+++ b/pkg/signature/signerverifier_test.go
@@ -158,7 +158,7 @@ func TestLoadDefaultSignerVerifier(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			sv, err := LoadSignerVerifierFromPrivateKey(tt.key(), tt.opts...)
+			sv, err := LoadDefaultSignerVerifier(tt.key(), tt.opts...)
 			if err != nil {
 				t.Fatalf("unexpected error creating signer/verifier: %v", err)
 			}

--- a/pkg/signature/signerverifier_test.go
+++ b/pkg/signature/signerverifier_test.go
@@ -17,7 +17,10 @@ package signature
 import (
 	"bytes"
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/rsa"
 	"encoding/base64"
 	"testing"
@@ -79,4 +82,109 @@ func TestConvertED25519ph(t *testing.T) {
 	sig, _ := base64.StdEncoding.DecodeString("cnafwd8DKq2nQ564eN66ckYV8anVFGFi5vaYiQg2aal7ej/J0/OE0PPdKHLHe9wdzWRMFy5MpurRD/2cGXGLBQ==")
 	testingSigner(t, newSV, "ed25519", crypto.SHA256, message)
 	testingVerifier(t, newSV, "ed25519", crypto.SHA256, sig, message)
+}
+
+func TestLoadDefaultSignerVerifier(t *testing.T) {
+	tts := []struct {
+		name         string
+		key          func() crypto.PrivateKey
+		opts         []LoadOption
+		expectedType string
+	}{
+		{
+			name: "rsa-2048",
+			key: func() crypto.PrivateKey {
+				rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("unexpected error creating rsa key: %v", err)
+				}
+				return rsaKey
+			},
+			expectedType: "rsa",
+		},
+		{
+			name: "rsa-2048-pss",
+			key: func() crypto.PrivateKey {
+				rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("unexpected error creating rsa key: %v", err)
+				}
+				return rsaKey
+			},
+			opts: []LoadOption{
+				options.WithRSAPSS(&rsa.PSSOptions{
+					Hash: crypto.SHA256,
+				}),
+			},
+			expectedType: "rsa-pss",
+		},
+		{
+			name: "ecdsa-p256",
+			key: func() crypto.PrivateKey {
+				ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error creating ecdsa key: %v", err)
+				}
+				return ecdsaKey
+			},
+			expectedType: "ecdsa",
+		},
+		{
+			name: "ed25519",
+			key: func() crypto.PrivateKey {
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error creating ed25519 key: %v", err)
+				}
+				return priv
+			},
+			expectedType: "ed25519",
+		},
+		{
+			name: "ed25519-ph",
+			key: func() crypto.PrivateKey {
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error creating ed25519 key: %v", err)
+				}
+				return priv
+			},
+			opts: []LoadOption{
+				options.WithED25519ph(),
+			},
+			expectedType: "ed25519-ph",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			sv, err := LoadSignerVerifierFromPrivateKey(tt.key(), tt.opts...)
+			if err != nil {
+				t.Fatalf("unexpected error creating signer/verifier: %v", err)
+			}
+
+			switch tt.expectedType {
+			case "rsa":
+				if _, ok := sv.(*RSAPKCS1v15SignerVerifier); !ok {
+					t.Fatalf("expected signer/verifier to be an rsa signer/verifier")
+				}
+			case "rsa-pss":
+				if _, ok := sv.(*RSAPSSSignerVerifier); !ok {
+					t.Fatalf("expected signer/verifier to be an rsa-pss signer/verifier")
+				}
+			case "ecdsa":
+				if _, ok := sv.(*ECDSASignerVerifier); !ok {
+					t.Fatalf("expected signer/verifier to be an ecdsa signer/verifier")
+				}
+			case "ed25519":
+				if _, ok := sv.(*ED25519SignerVerifier); !ok {
+					t.Fatalf("expected signer/verifier to be an ed25519 signer/verifier")
+				}
+			case "ed25519-ph":
+				if _, ok := sv.(*ED25519phSignerVerifier); !ok {
+					t.Fatalf("expected signer/verifier to be an ed25519-ph signer/verifier")
+				}
+			}
+		})
+	}
 }

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -137,10 +137,10 @@ func LoadVerifierFromPEMFileWithOpts(path string, opts ...LoadOption) (Verifier,
 	return LoadVerifierWithOpts(pubKey, opts...)
 }
 
-// LoadVerifierFromPublicKey returns a signature.Verifier based on the public key.
+// LoadDefaultVerifier returns a signature.Verifier based on the public key.
 // Each public key has a corresponding PublicKeyDetails associated in the
 // Sigstore ecosystem, see Algorithm Registry for more details.
-func LoadVerifierFromPublicKey(publicKey crypto.PublicKey, opts ...LoadOption) (Verifier, error) {
+func LoadDefaultVerifier(publicKey crypto.PublicKey, opts ...LoadOption) (Verifier, error) {
 	algorithmDetails, err := GetDefaultAlgorithmDetails(publicKey, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -136,3 +136,14 @@ func LoadVerifierFromPEMFileWithOpts(path string, opts ...LoadOption) (Verifier,
 
 	return LoadVerifierWithOpts(pubKey, opts...)
 }
+
+// LoadVerifierFromPublicKey returns a signature.Verifier based on the public key.
+// Each public key has a corresponding PublicKeyDetails associated in the
+// Sigstore ecosystem, see Algorithm Registry for more details.
+func LoadVerifierFromPublicKey(publicKey crypto.PublicKey) (Verifier, error) {
+	algorithmDetails, err := GetDefaultAlgorithmDetails(publicKey)
+	if err != nil {
+		return nil, err
+	}
+	return LoadVerifierWithOpts(publicKey, options.WithHash(algorithmDetails.GetHashType()), options.WithED25519ph())
+}

--- a/pkg/signature/verifier_test.go
+++ b/pkg/signature/verifier_test.go
@@ -16,9 +16,14 @@ package signature
 
 import (
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"testing"
+
+	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 func TestLoadUnsafeVerifier(t *testing.T) {
@@ -48,5 +53,113 @@ func TestLoadVerifier(t *testing.T) {
 	pubKey, _ := verifier.PublicKey()
 	if !key.PublicKey.Equal(pubKey) {
 		t.Fatalf("public keys were not equal")
+	}
+}
+
+func TestLoadDefaultVerifier(t *testing.T) {
+	tts := []struct {
+		name         string
+		key          func() crypto.PrivateKey
+		opts         []LoadOption
+		expectedType string
+	}{
+		{
+			name: "rsa-2048",
+			key: func() crypto.PrivateKey {
+				rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("unexpected error creating rsa key: %v", err)
+				}
+				return rsaKey
+			},
+			expectedType: "rsa",
+		},
+		{
+			name: "rsa-2048-pss",
+			key: func() crypto.PrivateKey {
+				rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				if err != nil {
+					t.Fatalf("unexpected error creating rsa key: %v", err)
+				}
+				return rsaKey
+			},
+			opts: []LoadOption{
+				options.WithRSAPSS(&rsa.PSSOptions{
+					Hash: crypto.SHA256,
+				}),
+			},
+			expectedType: "rsa-pss",
+		},
+		{
+			name: "ecdsa-p256",
+			key: func() crypto.PrivateKey {
+				ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error creating ecdsa key: %v", err)
+				}
+				return ecdsaKey
+			},
+			expectedType: "ecdsa",
+		},
+		{
+			name: "ed25519",
+			key: func() crypto.PrivateKey {
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error creating ed25519 key: %v", err)
+				}
+				return priv
+			},
+			expectedType: "ed25519",
+		},
+		{
+			name: "ed25519-ph",
+			key: func() crypto.PrivateKey {
+				_, priv, err := ed25519.GenerateKey(rand.Reader)
+				if err != nil {
+					t.Fatalf("unexpected error creating ed25519 key: %v", err)
+				}
+				return priv
+			},
+			opts: []LoadOption{
+				options.WithED25519ph(),
+			},
+			expectedType: "ed25519-ph",
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			privKey := tt.key()
+			signer, _ := privKey.(crypto.Signer)
+			pubKey := signer.Public()
+			sv, err := LoadVerifierFromPublicKey(pubKey, tt.opts...)
+			if err != nil {
+				t.Fatalf("unexpected error creating verifier: %v", err)
+			}
+
+			switch tt.expectedType {
+			case "rsa":
+				if _, ok := sv.(*RSAPKCS1v15Verifier); !ok {
+					t.Fatalf("expected verifier to be an rsa verifier")
+				}
+			case "rsa-pss":
+				if _, ok := sv.(*RSAPSSVerifier); !ok {
+					t.Fatalf("expected verifier to be an rsa-pss verifier")
+				}
+			case "ecdsa":
+				if _, ok := sv.(*ECDSAVerifier); !ok {
+					t.Fatalf("expected verifier to be an ecdsa verifier")
+				}
+			case "ed25519":
+				if _, ok := sv.(*ED25519Verifier); !ok {
+					t.Fatalf("expected verifier to be an ed25519 verifier")
+				}
+			case "ed25519-ph":
+				if _, ok := sv.(*ED25519phVerifier); !ok {
+					t.Fatalf("expected verifier to be an ed25519-ph verifier")
+				}
+			}
+		})
 	}
 }

--- a/pkg/signature/verifier_test.go
+++ b/pkg/signature/verifier_test.go
@@ -133,7 +133,7 @@ func TestLoadDefaultVerifier(t *testing.T) {
 			privKey := tt.key()
 			signer, _ := privKey.(crypto.Signer)
 			pubKey := signer.Public()
-			sv, err := LoadVerifierFromPublicKey(pubKey, tt.opts...)
+			sv, err := LoadDefaultVerifier(pubKey, tt.opts...)
 			if err != nil {
 				t.Fatalf("unexpected error creating verifier: %v", err)
 			}


### PR DESCRIPTION
#### Summary
As we make the Sigstore ecosystem more crypto agile, we realized that right now it is using some uncommon algorithms, like ECDSA-P384 with the SHA256 hash algorithm. However, we want the crypto-agility to be controlled and limited to a set of algorithms (see `AlgorithmRegistry`). Moreover, we want the agility to be mainly about supporting multiple key types, rather than multiple algorithms for the same key type. Thus, this PR introduces a single point where the defaults are defined.

This is going to simplify other changes across the Sigstore ecosystem, given that often enough the only information you have is the public key. Being able to derive the signing algorithm to use (or used to sign a blob) means we don't need to store or pass around any extra information (e.g. the hash function), because that can be derived automatically from the key.

See https://github.com/sigstore/sig-clients/issues/16 .

#### Release Note
- Introduce default `AlgorithmDetails` for public keys based on their types.
