### PR TITLE
change how we copy keys in azure test case

### DIFF
--- a/pkg/signature/kms/azure/client_test.go
+++ b/pkg/signature/kms/azure/client_test.go
@@ -137,8 +137,11 @@ func generatePublicKey(azureKeyType string) (azkeys.JSONWebKey, error) {
 			return azkeys.JSONWebKey{}, fmt.Errorf("failed to cast public key to esdsa public key")
 		}
 
-		key.X = ecdsaPub.X.Bytes()
-		key.Y = ecdsaPub.Y.Bytes()
+		curveByteSize := 32 // this assumes P256 as coded above
+		key.X = make([]byte, curveByteSize)
+		key.Y = make([]byte, curveByteSize)
+		ecdsaPub.X.FillBytes(key.X)
+		ecdsaPub.Y.FillBytes(key.Y)
 
 		return key, nil
 	case azkeys.KeyTypeRSA, azkeys.KeyTypeRSAHSM:


### PR DESCRIPTION
Fixes: #2035 

The intermittent failure we're seeing on line ~180 of `client_test.go` where the length of the X coordinate (ecdsaPubKey.X.Bytes()) is sometimes 32 and sometimes 31 bytes is almost certainly due to how Go's `math/big` package handles byte conversions, specifically the omission of leading zeros.

Here's the breakdown:

ECDSA Public Keys and Coordinates: An ECDSA public key consists of a point (X, Y) on an elliptic curve. In Go's `crypto/ecdsa`, the PublicKey struct stores these coordinates X and Y as *big.Int (pointers to large integers).

Curve Size (P-256): Azure Key Vault typically uses standard NIST curves like P-256 (also known as secp256r1 or prime256v1) for ECDSA keys. For P-256, the curve operates over a 256-bit field. This means that both the X and Y coordinates are integers whose values are between 0 and 2^256 - 1.

`big.Int.Bytes()` Behavior: The crucial point is the behavior of the `Bytes()` method on a `*big.Int` in Go:

It returns the absolute value of the integer as a big-endian byte slice.
Critically, it returns the smallest possible byte slice required to represent the number. It explicitly omits leading zero bytes.
The Root Cause of Intermittency:

A 256-bit number requires 32 bytes for its full representation (256 bits / 8 bits/byte = 32 bytes).
Most of the time, the randomly generated X coordinate of a P-256 public key will be a large number requiring all 32 bytes. Its most significant byte (the first byte in the big-endian slice) will be non-zero. In this case, X.Bytes() returns a slice of length 32.
However, sometimes the generated X coordinate might be a smaller number by chance. Specifically, if the value of X is less than 2^248 (which is 0x01 followed by 31 zero bytes), its 32-byte representation would start with a 0x00.
When `X.Bytes()` is called on such a number, it omits this leading zero byte, resulting in a byte slice of length 31.
This perfectly explains the intermittent nature: the test only fails when the underlying key retrieved from Azure happens to have an X coordinate whose value is numerically small enough (< 2^248) to have a leading zero in its 32-byte representation.
Incorrect Assumption in Test: The test code around line 180 likely assumes `ecdsaPubKey.X.Bytes()` will always return a 32-byte slice for a P-256 key. This assumption is incorrect due to the behavior of `Bytes()`.