### PR TITLE
Drop redundant aws-sdk-go dependency in the e2e kms tests

### DIFF
--- a/pkg/signature/kms/aws/e2e_test.go
+++ b/pkg/signature/kms/aws/e2e_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
-	awskms "github.com/aws/aws-sdk-go/service/kms"
+	awskms "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 )
@@ -84,11 +84,11 @@ func (suite *AWSSuite) TestInvalidProvider() {
 func (suite *AWSSuite) TestCreateKey() {
 	provider := suite.GetProvider("alias/provider")
 
-	key, err := provider.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key, err := provider.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key)
 
-	key2, err := provider.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key2, err := provider.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key)
 
@@ -100,7 +100,7 @@ func (suite *AWSSuite) TestCreateKeyByID() {
 	provider := suite.GetProvider("1234abcd-12ab-34cd-56ef-1234567890ab")
 
 	// CreateKey can only work with aliases, not IDs
-	key, err := provider.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key, err := provider.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Error(suite.T(), err)
 	require.Nil(suite.T(), key)
 }
@@ -108,7 +108,7 @@ func (suite *AWSSuite) TestCreateKeyByID() {
 func (suite *AWSSuite) TestSign() {
 	provider := suite.GetProvider("alias/TestSign")
 
-	key, err := provider.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key, err := provider.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key)
 
@@ -125,7 +125,7 @@ func (suite *AWSSuite) TestSign() {
 func (suite *AWSSuite) TestSHA384() {
 	provider := suite.GetProvider("alias/TestSHA384")
 
-	key, err := provider.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP384)
+	key, err := provider.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP384))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key)
 
@@ -149,7 +149,7 @@ func (suite *AWSSuite) TestSHA384() {
 func (suite *AWSSuite) TestPublicKey() {
 	provider := suite.GetProvider("alias/TestPubKeyVerify")
 
-	key, err := provider.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key, err := provider.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key)
 
@@ -173,7 +173,7 @@ func (suite *AWSSuite) TestPublicKey() {
 func (suite *AWSSuite) TestVerify() {
 	provider := suite.GetProvider("alias/TestVerify")
 
-	key, err := provider.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key, err := provider.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key)
 
@@ -193,7 +193,7 @@ func (suite *AWSSuite) TestTwoProviders() {
 	provider1 := suite.GetProvider("alias/TestTwoProviders")
 	provider2 := suite.GetProvider("alias/TestTwoProviders")
 
-	key, err := provider1.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key, err := provider1.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key)
 
@@ -210,11 +210,11 @@ func (suite *AWSSuite) TestBadSignature() {
 	provider1 := suite.GetProvider("alias/TestBadSignature1")
 	provider2 := suite.GetProvider("alias/TestBadSignature2")
 
-	key1, err := provider1.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key1, err := provider1.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key1)
 
-	key2, err := provider2.CreateKey(context.Background(), awskms.CustomerMasterKeySpecEccNistP256)
+	key2, err := provider2.CreateKey(context.Background(), string(awskms.CustomerMasterKeySpecEccNistP256))
 	require.Nil(suite.T(), err)
 	require.NotNil(suite.T(), key2)
 
@@ -232,12 +232,12 @@ func (suite *AWSSuite) TestBadSignature() {
 
 func (suite *AWSSuite) TestKeyTypes() {
 	for _, cmkSpec := range []string{
-		awskms.CustomerMasterKeySpecRsa2048,
-		awskms.CustomerMasterKeySpecRsa3072,
-		awskms.CustomerMasterKeySpecRsa4096,
-		awskms.CustomerMasterKeySpecEccNistP256,
-		awskms.CustomerMasterKeySpecEccNistP384,
-		awskms.CustomerMasterKeySpecEccNistP521,
+		string(awskms.CustomerMasterKeySpecRsa2048),
+		string(awskms.CustomerMasterKeySpecRsa3072),
+		string(awskms.CustomerMasterKeySpecRsa4096),
+		string(awskms.CustomerMasterKeySpecEccNistP256),
+		string(awskms.CustomerMasterKeySpecEccNistP384),
+		string(awskms.CustomerMasterKeySpecEccNistP521),
 		// awskms.CustomerMasterKeySpecEccSecgP256k1, // unsupported by localstack at the moment
 	} {
 		suite.T().Run(fmt.Sprintf("KeyType-%s", cmkSpec), func(t *testing.T) {
@@ -262,7 +262,7 @@ func (suite *AWSSuite) TestCancelContext() {
 	cancel()
 
 	provider := suite.GetProvider("alias/TestCancelContext")
-	key, err := provider.CreateKey(ctx, awskms.CustomerMasterKeySpecEccNistP256)
+	key, err := provider.CreateKey(ctx, string(awskms.CustomerMasterKeySpecEccNistP256))
 	assert.Error(suite.T(), err)
 	assert.Contains(suite.T(), err.Error(), context.Canceled.Error())
 	assert.Nil(suite.T(), key)

--- a/pkg/signature/kms/aws/go.mod
+++ b/pkg/signature/kms/aws/go.mod
@@ -7,7 +7,6 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/aws/aws-sdk-go v1.55.8
 	github.com/aws/aws-sdk-go-v2 v1.38.3
 	github.com/aws/aws-sdk-go-v2/config v1.31.2
 	github.com/aws/aws-sdk-go-v2/service/kms v1.45.1
@@ -31,7 +30,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.2 // indirect
 	github.com/google/go-containerregistry v0.20.6 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/letsencrypt/boulder v0.20250721.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/pkg/signature/kms/aws/go.sum
+++ b/pkg/signature/kms/aws/go.sum
@@ -1,5 +1,3 @@
-github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
-github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.38.3 h1:B6cV4oxnMs45fql4yRH+/Po/YU+597zgWqvDpYMturk=
 github.com/aws/aws-sdk-go-v2 v1.38.3/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/config v1.31.2 h1:NOaSZpVGEH2Np/c1toSeW0jooNl+9ALmsUTZ8YvkJR0=
@@ -32,7 +30,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-jose/go-jose/v4 v4.1.2 h1:TK/7NqRQZfgAh+Td8AlsrvtPoUyiHh0LqVvokh+1vHI=
@@ -47,10 +44,6 @@ github.com/google/go-containerregistry v0.20.6 h1:cvWX87UxxLgaH76b4hIvya6Dzz9qHB
 github.com/google/go-containerregistry v0.20.6/go.mod h1:T0x8MuoAoKX/873bkeSfLD2FAkwCDf9/HZgsFJ02E2Y=
 github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmhodges/clock v1.2.0 h1:eq4kys+NI0PLngzaHEe7AmPT90XMGIEySD1JfV1PDIs=
 github.com/jmhodges/clock v1.2.0/go.mod h1:qKjhA7x7u/lQpPB1XAqX1b1lCI/w3/fNuYpI/ZjLynI=
 github.com/letsencrypt/boulder v0.20250721.0 h1:zXQpr7C7hlNxDzP9N0oC5KWZ7/g3xnS/+C30ImRxaVw=
@@ -73,7 +66,6 @@ github.com/secure-systems-lab/go-securesystemslib v0.9.1 h1:nZZaNz4DiERIQguNy0cL
 github.com/secure-systems-lab/go-securesystemslib v0.9.1/go.mod h1:np53YzT0zXGMv6x4iEWc9Z59uR+x+ndLwCLqPYpLXVU=
 github.com/sigstore/protobuf-specs v0.5.0 h1:F8YTI65xOHw70NrvPwJ5PhAzsvTnuJMGLkA4FIkofAY=
 github.com/sigstore/protobuf-specs v0.5.0/go.mod h1:+gXR+38nIa2oEupqDdzg4qSBT0Os+sP7oYv6alWewWc=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.11.0 h1:ib4sjIrwZKxE5u/Japgo/7SJV3PvgjGiRNAvTVGqQl8=
 github.com/stretchr/testify v1.11.0/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C1wj2THlRK+oAhjeS/TRQwMfkIuet3w0=
@@ -102,7 +94,5 @@ google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyM
 google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
-gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
#### Summary

This PR replaces `github.com/aws/aws-sdk-go` with the newer `github.com/aws/aws-sdk-go-v2` in the KMS e2e tests. This change allows us to remove dependency on `github.com/aws/aws-sdk-go`.

#### Release Note

NONE