### PR TITLE
feat(hashivault): token helper tests

### DIFF
--- a/pkg/signature/kms/hashivault/client.go
+++ b/pkg/signature/kms/hashivault/client.go
@@ -26,15 +26,14 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	vault "github.com/hashicorp/vault/api"
 	config "github.com/hashicorp/vault/api/cliconfig"
 	"github.com/jellydator/ttlcache/v3"
-	"github.com/mitchellh/go-homedir"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	sigkms "github.com/sigstore/sigstore/pkg/signature/kms"
@@ -89,10 +88,10 @@ func parseReference(resourceID string) (keyPath string, err error) {
 	v := referenceRegex.FindStringSubmatch(resourceID)
 	if len(v) < i+1 {
 		err = fmt.Errorf("invalid vault format %q: %w", resourceID, err)
-		return
+		return keyPath, err
 	}
 	keyPath = v[i]
-	return
+	return keyPath, err
 }
 
 func newHashivaultClient(address, token, transitSecretEnginePath, keyResourceID string, keyVersion uint64) (*hashivaultClient, error) {
@@ -133,33 +132,28 @@ func newHashivaultClient(address, token, transitSecretEnginePath, keyResourceID 
 	}
 
 	if token == "" {
+		// token helper will use the configured token helper in ~/.vault
+		// if no token helper is defined the default token helper will look for the ~/.vault-token file
 		log.Printf("VAULT_TOKEN or BAO_TOKEN not set, trying to find token helper")
 
-		// try token helper
 		tokenHelper, err := config.DefaultTokenHelper()
+		if tokenHelper == nil {
+			return nil, fmt.Errorf("no token helper configured and VAULT_TOKEN not set")
+		}
+		if tokenHelper.Path() != "" {
+			log.Printf("Using custom token helper: %s", tokenHelper.Path())
+		}
 		if err == nil {
 			if t, err := tokenHelper.Get(); err == nil && t != "" {
 				token = t
 			} else {
-				log.Printf("no token found via helper, trying ~/.vault-token")
+				if strings.HasSuffix(tokenHelper.Path(), "/.vault-token") {
+					return nil, fmt.Errorf("no token helper configured and ~/.vault-token file not found or empty")
+				}
+				return nil, fmt.Errorf("token helper failed to get token")
 			}
 		} else {
-			log.Printf("no token helper configured, trying ~/.vault-token")
-		}
-
-		// read from ~/.vault-token
-		if token == "" {
-			homeDir, err := homedir.Dir()
-			if err != nil {
-				return nil, fmt.Errorf("get home directory: %w", err)
-			}
-
-			tokenFromFile, err := os.ReadFile(filepath.Join(homeDir, ".vault-token"))
-			if err != nil {
-				return nil, fmt.Errorf("read .vault-token file: %w", err)
-			}
-
-			token = string(tokenFromFile)
+			return nil, fmt.Errorf("token helper returned an error: %w", err)
 		}
 	}
 

--- a/pkg/signature/kms/hashivault/go.mod
+++ b/pkg/signature/kms/hashivault/go.mod
@@ -7,7 +7,6 @@ go 1.25.0
 require (
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/jellydator/ttlcache/v3 v3.4.1
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sigstore/sigstore v1.6.4
 	github.com/stretchr/testify v1.11.1
 )
@@ -26,6 +25,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-7 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/natefinch/atomic v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/pkg/signature/kms/hashivault/hashivault_test.go
+++ b/pkg/signature/kms/hashivault/hashivault_test.go
@@ -15,7 +15,193 @@
 
 package hashivault
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewHashivaultClient(t *testing.T) {
+	tests := []struct {
+		name                        string
+		address                     string
+		token                       string
+		transitSecretEnginePath     string
+		keyResourceID               string
+		keyVersion                  uint64
+		addressEnv                  string
+		tokenEnv                    string
+		vaultTokenFile              string
+		tokenHelperScript           string
+		wantErr                     bool
+		wantAddress                 string
+		wantToken                   string
+		wantTransitSecretEnginePath string
+	}{
+		{
+			name:                        "directly provided parameters",
+			address:                     "https://vault.example.com",
+			token:                       "hvc.exampletoken",
+			transitSecretEnginePath:     "",
+			keyResourceID:               "hashivault://test",
+			keyVersion:                  1,
+			wantErr:                     false,
+			wantAddress:                 "https://vault.example.com",
+			wantToken:                   "hvc.exampletoken",
+			wantTransitSecretEnginePath: "transit",
+		},
+		{
+			name:                        "environment variables",
+			keyResourceID:               "hashivault://test",
+			keyVersion:                  1,
+			addressEnv:                  "https://vault.example.com",
+			tokenEnv:                    "hvc.exampletoken",
+			wantErr:                     false,
+			wantAddress:                 "https://vault.example.com",
+			wantToken:                   "hvc.exampletoken",
+			wantTransitSecretEnginePath: "transit",
+		},
+		{
+			name:                        "default token helper ~/.vault-token",
+			address:                     "https://vault.example.com",
+			keyResourceID:               "hashivault://test",
+			keyVersion:                  1,
+			vaultTokenFile:              "hvc.exampletoken",
+			wantErr:                     false,
+			wantAddress:                 "https://vault.example.com",
+			wantToken:                   "hvc.exampletoken",
+			wantTransitSecretEnginePath: "transit",
+		},
+		{
+			name:          "custom token helper script",
+			address:       "https://vault.example.com",
+			keyResourceID: "hashivault://test",
+			keyVersion:    1,
+			tokenHelperScript: `#!/bin/bash
+set -euo pipefail
+
+cmd="${1}"
+
+case "$cmd" in
+get)
+	# Print only the token to stdout
+	echo -n "hvc.exampletoken"
+	;;
+store)
+	# Read token from stdin (ignored)
+	cat >/dev/null
+	;;
+erase)
+	# Nothing to delete
+	;;
+*)
+	echo "unknown command: $cmd" >&2
+	exit 1
+	;;
+esac
+			`,
+			wantErr:                     false,
+			wantAddress:                 "https://vault.example.com",
+			wantToken:                   "hvc.exampletoken",
+			wantTransitSecretEnginePath: "transit",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// backup environment variables
+			oldAddressEnv := os.Getenv("VAULT_ADDR")
+			oldTokenEnv := os.Getenv("VAULT_TOKEN")
+			oldTransitSecretEnginePathEnv := os.Getenv("VAULT_TRANSIT_SECRET_ENGINE_PATH")
+			os.Unsetenv("VAULT_ADDR")
+			os.Unsetenv("VAULT_TOKEN")
+			os.Unsetenv("VAULT_TRANSIT_SECRET_ENGINE_PATH")
+			defer func() {
+				os.Setenv("VAULT_ADDR", oldAddressEnv)
+				os.Setenv("VAULT_TOKEN", oldTokenEnv)
+				os.Setenv("VAULT_TRANSIT_SECRET_ENGINE_PATH", oldTransitSecretEnginePathEnv)
+			}()
+
+			// backup files
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				t.Fatalf("failed to get user home directory: %v", err)
+			}
+			oldVaultTokenFile, err := os.ReadFile(filepath.Join(homeDir, ".vault-token"))
+			if err == nil {
+				defer os.WriteFile(filepath.Join(homeDir, ".vault-token"), oldVaultTokenFile, 0o600)
+			} else {
+				defer os.Remove(filepath.Join(homeDir, ".vault-token"))
+			}
+			os.Remove(filepath.Join(homeDir, ".vault-token"))
+			oldVaultConfigFile, err := os.ReadFile(filepath.Join(homeDir, ".vault"))
+			if err == nil {
+				defer os.WriteFile(filepath.Join(homeDir, ".vault"), oldVaultConfigFile, 0o600)
+			} else {
+				defer os.Remove(filepath.Join(homeDir, ".vault"))
+			}
+			os.Remove(filepath.Join(homeDir, ".vault"))
+
+			// prepare environment variables and files
+			if tt.addressEnv != "" {
+				t.Setenv("VAULT_ADDR", tt.addressEnv)
+			}
+			if tt.tokenEnv != "" {
+				t.Setenv("VAULT_TOKEN", tt.tokenEnv)
+			}
+			if tt.vaultTokenFile != "" {
+				// write to ~/.vault-token
+				err = os.WriteFile(filepath.Join(homeDir, ".vault-token"), []byte(tt.vaultTokenFile), 0o600)
+				if err != nil {
+					t.Fatalf("failed to write to ~/.vault-token: %v", err)
+				}
+			}
+			if tt.tokenHelperScript != "" {
+				// write "token_helper = \"<tmp-file-for-token-helper-script>\" to ~/.vault
+				// write tt.tokenHelperScript to <tmp-file-for-token-helper-script>
+				tmpFile, err := os.CreateTemp("", "token-helper.sh")
+				if err != nil {
+					t.Fatalf("failed to create temp file for token helper script: %v", err)
+				}
+				defer os.Remove(tmpFile.Name())
+				_, err = tmpFile.WriteString(tt.tokenHelperScript)
+				if err != nil {
+					t.Fatalf("failed to write to temp file for token helper script: %v", err)
+				}
+				err = tmpFile.Chmod(0o700)
+				if err != nil {
+					t.Fatalf("failed to chmod temp file for token helper script: %v", err)
+				}
+				tmpFile.Close()
+
+				// write to ~/.vault
+				vaultConfigContent := []byte("token_helper = \"" + tmpFile.Name() + "\"\n")
+				err = os.WriteFile(filepath.Join(homeDir, ".vault"), vaultConfigContent, 0o600)
+				if err != nil {
+					t.Fatalf("failed to write to ~/.vault: %v", err)
+				}
+			}
+
+			// setup client
+			client, err := newHashivaultClient(tt.address, tt.token, tt.transitSecretEnginePath, tt.keyResourceID, tt.keyVersion)
+
+			// check results
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newHashivaultClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if client.client.Address() != tt.wantAddress {
+				t.Errorf("newHashivaultClient() got address = %v, want %v", client.client.Address(), tt.wantAddress)
+			}
+			token := client.client.Token()
+			if token != tt.wantToken {
+				t.Errorf("newHashivaultClient() got token = %v, want %v", token, tt.wantToken)
+			}
+			if client.transitSecretEnginePath != tt.wantTransitSecretEnginePath {
+				t.Errorf("newHashivaultClient() got transitSecretEnginePath = %v, want %v", client.transitSecretEnginePath, tt.wantTransitSecretEnginePath)
+			}
+		})
+	}
+}
 
 func TestParseReference(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

No issue, addition to PR #2174 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

In #2174 vault token helpers were implemented. Ive added a unit test for this function that checks the different options that can be used to provide info to the `newHashiVaultClient` function.

The tests showed that the DefaultTokenHelper already looks for `~/.vault-token` file so the logic is not needed anymore.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
