### PR TITLE
feat: add KeyMarshaller interface for consistent marshalling and unma…

### DIFF
--- a/pkg/cryptoutils/keymarshaller.go
+++ b/pkg/cryptoutils/keymarshaller.go
@@ -1,0 +1,167 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cryptoutils
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
+)
+
+// KeyMarshaller provides an interface for key marshalling and unmarshalling operations.
+type KeyMarshaller interface {
+	// MarshalPublicKeyToPEM converts a crypto.PublicKey to PEM format
+	MarshalPublicKeyToPEM(pub crypto.PublicKey) ([]byte, error)
+
+	// UnmarshalPEMToPublicKey converts PEM bytes to crypto.PublicKey
+	UnmarshalPEMToPublicKey(pemBytes []byte) (crypto.PublicKey, error)
+
+	// MarshalPublicKeyToDER converts a crypto.PublicKey to DER format
+	MarshalPublicKeyToDER(pub crypto.PublicKey) ([]byte, error)
+
+	// UnmarshalDERToPublicKey converts DER bytes to crypto.PublicKey
+	UnmarshalDERToPublicKey(derBytes []byte) (crypto.PublicKey, error)
+
+	// MarshalPrivateKeyToPEM converts a crypto.PrivateKey to PEM format
+	MarshalPrivateKeyToPEM(priv crypto.PrivateKey) ([]byte, error)
+
+	// UnmarshalPEMToPrivateKey converts PEM bytes to crypto.PrivateKey
+	UnmarshalPEMToPrivateKey(pemBytes []byte, pf PassFunc) (crypto.PrivateKey, error)
+
+	// UnmarshalDERToPrivateKey converts DER bytes to crypto.PrivateKey
+	UnmarshalDERToPrivateKey(derBytes []byte) (crypto.PrivateKey, error)
+}
+
+// defaultKeyMarshaller implements KeyMarshaller using golang x509 functions
+type defaultKeyMarshaller struct{}
+
+// MarshalPublicKeyToPEM converts a crypto.PublicKey to PEM format
+func (kp *defaultKeyMarshaller) MarshalPublicKeyToPEM(pub crypto.PublicKey) ([]byte, error) {
+	if pub == nil {
+		return nil, errors.New("empty key")
+	}
+	derBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: derBytes,
+	}), nil
+}
+
+// UnmarshalPEMToPublicKey converts PEM bytes to crypto.PublicKey
+func (kp *defaultKeyMarshaller) UnmarshalPEMToPublicKey(pemBytes []byte) (crypto.PublicKey, error) {
+	derBlock, _ := pem.Decode(pemBytes)
+	if derBlock == nil {
+		return nil, errors.New("PEM decoding failed")
+	}
+	switch derBlock.Type {
+	case "PUBLIC KEY":
+		return x509.ParsePKIXPublicKey(derBlock.Bytes)
+	case "RSA PUBLIC KEY":
+		return x509.ParsePKCS1PublicKey(derBlock.Bytes)
+	default:
+		return nil, fmt.Errorf("unknown Public key PEM file type: %v. Are you passing the correct public key?", derBlock.Type)
+	}
+}
+
+// MarshalPublicKeyToDER converts a crypto.PublicKey to DER format
+func (kp *defaultKeyMarshaller) MarshalPublicKeyToDER(pub crypto.PublicKey) ([]byte, error) {
+	if pub == nil {
+		return nil, errors.New("empty key")
+	}
+	return x509.MarshalPKIXPublicKey(pub)
+}
+
+// UnmarshalDERToPublicKey converts DER bytes to crypto.PublicKey
+func (kp *defaultKeyMarshaller) UnmarshalDERToPublicKey(derBytes []byte) (crypto.PublicKey, error) {
+	return x509.ParsePKIXPublicKey(derBytes)
+}
+
+// MarshalPrivateKeyToPEM converts a crypto.PrivateKey to PEM format
+func (kp *defaultKeyMarshaller) MarshalPrivateKeyToPEM(priv crypto.PrivateKey) ([]byte, error) {
+	if priv == nil {
+		return nil, errors.New("empty key")
+	}
+	derBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: derBytes,
+	}), nil
+}
+
+// UnmarshalPEMToPrivateKey converts PEM bytes to crypto.PrivateKey
+func (kp *defaultKeyMarshaller) UnmarshalPEMToPrivateKey(pemBytes []byte, pf PassFunc) (crypto.PrivateKey, error) {
+	derBlock, _ := pem.Decode(pemBytes)
+	if derBlock == nil {
+		return nil, errors.New("PEM decoding failed")
+	}
+	switch derBlock.Type {
+	case "PRIVATE KEY":
+		return x509.ParsePKCS8PrivateKey(derBlock.Bytes)
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(derBlock.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(derBlock.Bytes)
+	case "ENCRYPTED SIGSTORE PRIVATE KEY", "ENCRYPTED COSIGN PRIVATE KEY":
+		derBytes := derBlock.Bytes
+		if pf != nil {
+			password, err := pf(false)
+			if err != nil {
+				return nil, err
+			}
+			if password != nil {
+				derBytes, err = encrypted.Decrypt(derBytes, password)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+		return x509.ParsePKCS8PrivateKey(derBytes)
+	default:
+		return nil, fmt.Errorf("unknown private key PEM file type: %v", derBlock.Type)
+	}
+}
+
+// UnmarshalDERToPrivateKey converts DER bytes to crypto.PrivateKey
+func (kp *defaultKeyMarshaller) UnmarshalDERToPrivateKey(derBytes []byte) (crypto.PrivateKey, error) {
+	return x509.ParsePKCS8PrivateKey(derBytes)
+}
+
+// Global key marshaller instance
+var keyMarshaller KeyMarshaller = &defaultKeyMarshaller{}
+
+// SetKeyMarshaller sets the global key marshaller
+func SetKeyMarshaller(km KeyMarshaller) {
+	if km == nil {
+		keyMarshaller = &defaultKeyMarshaller{}
+	} else {
+		keyMarshaller = km
+	}
+}
+
+// GetKeyMarshaller returns the global key marshaller
+func GetKeyMarshaller() KeyMarshaller {
+	return keyMarshaller
+}

--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -26,7 +26,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/hex"
-	"encoding/pem"
 	"errors"
 	"fmt"
 
@@ -49,36 +48,22 @@ type subjectPublicKeyInfo struct {
 
 // UnmarshalPEMToPublicKey converts a PEM-encoded byte slice into a crypto.PublicKey
 func UnmarshalPEMToPublicKey(pemBytes []byte) (crypto.PublicKey, error) {
-	derBytes, _ := pem.Decode(pemBytes)
-	if derBytes == nil {
-		return nil, errors.New("PEM decoding failed")
-	}
-	switch derBytes.Type {
-	case string(PublicKeyPEMType):
-		return x509.ParsePKIXPublicKey(derBytes.Bytes)
-	case string(PKCS1PublicKeyPEMType):
-		return x509.ParsePKCS1PublicKey(derBytes.Bytes)
-	default:
-		return nil, fmt.Errorf("unknown Public key PEM file type: %v. Are you passing the correct public key?",
-			derBytes.Type)
-	}
+	return GetKeyMarshaller().UnmarshalPEMToPublicKey(pemBytes)
+}
+
+// UnmarshalDERToPublicKey converts DER bytes to crypto.PublicKey
+func UnmarshalDERToPublicKey(derBytes []byte) (crypto.PublicKey, error) {
+	return GetKeyMarshaller().UnmarshalDERToPublicKey(derBytes)
 }
 
 // MarshalPublicKeyToDER converts a crypto.PublicKey into a PKIX, ASN.1 DER byte slice
 func MarshalPublicKeyToDER(pub crypto.PublicKey) ([]byte, error) {
-	if pub == nil {
-		return nil, errors.New("empty key")
-	}
-	return x509.MarshalPKIXPublicKey(pub)
+	return GetKeyMarshaller().MarshalPublicKeyToDER(pub)
 }
 
 // MarshalPublicKeyToPEM converts a crypto.PublicKey into a PEM-encoded byte slice
 func MarshalPublicKeyToPEM(pub crypto.PublicKey) ([]byte, error) {
-	derBytes, err := MarshalPublicKeyToDER(pub)
-	if err != nil {
-		return nil, err
-	}
-	return PEMEncode(PublicKeyPEMType, derBytes), nil
+	return GetKeyMarshaller().MarshalPublicKeyToPEM(pub)
 }
 
 // SKID generates a 160-bit SHA-1 hash of the value of the BIT STRING

--- a/pkg/signature/algorithm_registry.go
+++ b/pkg/signature/algorithm_registry.go
@@ -251,6 +251,12 @@ func ParseSignatureAlgorithmFlag(flag string) (v1.PublicKeyDetails, error) {
 // with Ed25519ph. The Hash option is ignored if passed, because each of the
 // supported algorithms already has a default hash.
 func GetDefaultPublicKeyDetails(publicKey crypto.PublicKey, opts ...LoadOption) (v1.PublicKeyDetails, error) {
+	return getDefaultPublicKeyDetailsImpl(publicKey, opts...)
+}
+
+var getDefaultPublicKeyDetailsImpl = getDefaultPublicKeyDetails
+
+func getDefaultPublicKeyDetails(publicKey crypto.PublicKey, opts ...LoadOption) (v1.PublicKeyDetails, error) {
 	var rsaPSSOptions *rsa.PSSOptions
 	var useED25519ph bool
 	for _, o := range opts {

--- a/pkg/signature/verifier.go
+++ b/pkg/signature/verifier.go
@@ -47,6 +47,12 @@ func LoadVerifier(publicKey crypto.PublicKey, hashFunc crypto.Hash) (Verifier, e
 // LoadVerifierWithOpts returns a signature.Verifier based on the algorithm of the public key
 // provided that will use the hash function specified when computing digests.
 func LoadVerifierWithOpts(publicKey crypto.PublicKey, opts ...LoadOption) (Verifier, error) {
+	return loadVerifierWithOptsImpl(publicKey, opts...)
+}
+
+var loadVerifierWithOptsImpl = loadVerifierWithOpts
+
+func loadVerifierWithOpts(publicKey crypto.PublicKey, opts ...LoadOption) (Verifier, error) {
 	var rsaPSSOptions *rsa.PSSOptions
 	var useED25519ph bool
 	hashFunc := crypto.SHA256


### PR DESCRIPTION
…rshalling, and allow replacement of GetDefaultPublicKeyDetails and LoadVerifierWithOpts

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
This PR standardizes the marshalling/parsing behaviour within the sigstore `cryptoutils` package, defining an interface for bridging to the implementation.  The PR also introduces variables for the `signatures` package's `GetDefaultPublicKeyDetails` and `LoadVerifierWithOpts` methods so their implementation can also be bridged.

The primary reason for these changes is to enable research into alternative algorithms, such as post-quantum, but in a manner which does not impact the sigstore projects or their behaviour.

Please see issue #2195 for more information.

#### Release Note
NONE
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
