### PR TITLE
feat(client_credentials): Add overridable scopes for client creds

### DIFF
--- a/pkg/oauthflow/client_credentials.go
+++ b/pkg/oauthflow/client_credentials.go
@@ -92,7 +92,7 @@ func (d *DefaultFlowClientCredentials) clientCredentialsFlow(_ *oidc.Provider, c
 	data := url.Values{
 		"client_id":     []string{clientID},
 		"client_secret": []string{clientSecret},
-		"scope":         []string{"openid email"},
+		"scope":         []string{strings.Join(defaultScopes(), " ")},
 		"grant_type":    []string{"client_credentials"},
 	}
 	if redirectURL != "" {

--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -92,7 +92,7 @@ func (d *DeviceFlowTokenGetter) deviceFlow(p *oidc.Provider, clientID, redirectU
 
 	data := url.Values{
 		"client_id":             []string{clientID},
-		"scope":                 []string{"openid email"},
+		"scope":                 []string{strings.Join(defaultScopes(), " ")},
 		"code_challenge_method": []string{pkce.Method},
 		"code_challenge":        []string{pkce.Challenge},
 	}
@@ -137,7 +137,7 @@ func (d *DeviceFlowTokenGetter) deviceFlow(p *oidc.Provider, clientID, redirectU
 			"grant_type":    []string{"urn:ietf:params:oauth:grant-type:device_code"},
 			"client_id":     []string{clientID},
 			"device_code":   []string{parsed.DeviceCode},
-			"scope":         []string{"openid email"},
+			"scope":         []string{strings.Join(defaultScopes(), " ")},
 			"code_verifier": []string{pkce.Value},
 		}
 

--- a/pkg/oauthflow/flow_test.go
+++ b/pkg/oauthflow/flow_test.go
@@ -32,6 +32,25 @@ import (
 	"golang.org/x/oauth2"
 )
 
+func TestDefaultScopes(t *testing.T) {
+	t.Run("returns default when env unset", func(t *testing.T) {
+		t.Setenv("SIGSTORE_OAUTH_SCOPES", "")
+		got := defaultScopes()
+		want := []string{oidc.ScopeOpenID, "email"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("defaultScopes() = %v, want %v", got, want)
+		}
+	})
+	t.Run("returns env override", func(t *testing.T) {
+		t.Setenv("SIGSTORE_OAUTH_SCOPES", "openid email profile")
+		got := defaultScopes()
+		want := []string{"openid", "email", "profile"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("defaultScopes() = %v, want %v", got, want)
+		}
+	})
+}
+
 func TestGetCodeWorking(t *testing.T) {
 	desiredState := "foo"
 	desiredCode := "code"


### PR DESCRIPTION
#### Summary

This change introduces a configurable mechanism for OAuth scope selection across the `pkg/oauthflow` package.

Previously, OAuth scopes were hardcoded (`"openid email"`) across multiple OAuth flow implementations (`client_credentials.go`, `device.go`, and `flow.go`). This made scope customization difficult and required code changes for any variation in requested scopes.

This PR centralizes and standardizes scope management by introducing a new `defaultScopes()` function in `flow.go`. This function:

* Reads the `SIGSTORE_OAUTH_SCOPES` environment variable.
* Parses the value into scopes if set.
* Falls back to the default `"openid email"` scopes if the variable is unset.

All OAuth flow implementations have been updated to call `defaultScopes()` instead of using hardcoded scope values.

Additionally, a unit test was added to `flow_test.go` to validate:

* Default behavior when `SIGSTORE_OAUTH_SCOPES` is unset.
* Correct override behavior when the environment variable is defined.

**How to test:**

1. Run unit tests:

   ```
   go test ./pkg/oauthflow/...
   ```
2. Verify default behavior:

   * Ensure `SIGSTORE_OAUTH_SCOPES` is unset.
   * Confirm that scopes default to `openid email`.
3. Verify override behavior:

   ```
   export SIGSTORE_OAUTH_SCOPES="openid email profile"
   ```

   * Confirm that OAuth flows request the configured scopes.

This change improves flexibility while maintaining backward-compatible defaults.

Closes nothing, didn't bother to open an issue first.

---

#### Release Note

**Feature**

* OAuth scopes were made configurable via the `SIGSTORE_OAUTH_SCOPES` environment variable.
* OAuth flows now default to `openid email` but can be overridden without code changes.
* Centralized OAuth scope handling through a shared `defaultScopes()` function.

---

#### Documentation

Yes.

Documentation should be updated to describe the new `SIGSTORE_OAUTH_SCOPES` environment variable, including:

* Its purpose (overriding default OAuth scopes)
* Default behavior (`openid email`)
* Example usage:

  ```bash
  export SIGSTORE_OAUTH_SCOPES="openid email profile"
  ```

A corresponding documentation PR should be opened in:

[https://github.com/sigstore/docs.sigstore.dev](https://github.com/sigstore/docs.sigstore.dev)

to add a section under OAuth configuration explaining how administrators and users can customize OAuth scopes via environment variables.
