### PR TITLE
fix: remove leftover Go template syntax from success page

### DIFF
--- a/pkg/oauth/interactive.go
+++ b/pkg/oauth/interactive.go
@@ -65,18 +65,12 @@ func GetInteractiveSuccessHTML(autoclose bool, timeout int) (string, error) {
 					<span class="sigstore">sigstore </span>
 					<span>authentication successful!</span>
 				</div>
-				{{ if .Autoclose -}}
 				<small name="autoclose"></small>
 				<noscript>
 					<div class="content">
 						<span>You may now close this page.</span>
 					</div>
 				</noscript>
-				{{- else -}}
-				<div class="content">
-					<span>You may now close this page.</span>
-				</div>
-				{{- end }}
 			</div>
 			<div class="anchor">
 				<div class="links">


### PR DESCRIPTION
The text/template removal left behind {{ if }}/{{ else }}/{{ end }} directives in the raw HTML string, which rendered literally to users.

Fixes https://github.com/sigstore/cosign/issues/4845

Previously https://github.com/sigstore/sigstore/pull/2288
