### PR TITLE
Validate ed25519 public key length in verifier constructors

### DIFF
--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -101,6 +101,11 @@ func LoadED25519Verifier(pub ed25519.PublicKey) (*ED25519Verifier, error) {
 		return nil, errors.New("invalid ED25519 public key specified")
 	}
 
+	// check this to avoid a panic in ed25519.Verify and throw an error gracefully
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, errors.New("invalid size for ED25519 key")
+	}
+
 	return &ED25519Verifier{
 		publicKey: pub,
 	}, nil

--- a/pkg/signature/ed25519.go
+++ b/pkg/signature/ed25519.go
@@ -101,7 +101,6 @@ func LoadED25519Verifier(pub ed25519.PublicKey) (*ED25519Verifier, error) {
 		return nil, errors.New("invalid ED25519 public key specified")
 	}
 
-	// check this to avoid a panic in ed25519.Verify and throw an error gracefully
 	if len(pub) != ed25519.PublicKeySize {
 		return nil, errors.New("invalid size for ED25519 key")
 	}

--- a/pkg/signature/ed25519_test.go
+++ b/pkg/signature/ed25519_test.go
@@ -86,3 +86,18 @@ func TestED25519Verifier(t *testing.T) {
 	}
 	assertPublicKeyIsx509Marshalable(t, pub)
 }
+
+// TestED25519VerifierRejectsWrongKeySize ensures LoadED25519Verifier validates
+// the public key length up front and returns an error, instead of accepting a
+// malformed key and letting ed25519.Verify panic during VerifySignature. This
+// mirrors the guard already present in LoadED25519Signer.
+func TestED25519VerifierRejectsWrongKeySize(t *testing.T) {
+	for _, size := range []int{0, 16, 31, 33, 64} {
+		if _, err := LoadED25519Verifier(ed25519.PublicKey(make([]byte, size))); err == nil {
+			t.Errorf("expected error loading verifier with %d-byte key, got nil", size)
+		}
+	}
+	if _, err := LoadED25519Verifier(ed25519.PublicKey(make([]byte, ed25519.PublicKeySize))); err != nil {
+		t.Errorf("unexpected error loading verifier with valid key size: %v", err)
+	}
+}

--- a/pkg/signature/ed25519_test.go
+++ b/pkg/signature/ed25519_test.go
@@ -87,10 +87,6 @@ func TestED25519Verifier(t *testing.T) {
 	assertPublicKeyIsx509Marshalable(t, pub)
 }
 
-// TestED25519VerifierRejectsWrongKeySize ensures LoadED25519Verifier validates
-// the public key length up front and returns an error, instead of accepting a
-// malformed key and letting ed25519.Verify panic during VerifySignature. This
-// mirrors the guard already present in LoadED25519Signer.
 func TestED25519VerifierRejectsWrongKeySize(t *testing.T) {
 	for _, size := range []int{0, 16, 31, 33, 64} {
 		if _, err := LoadED25519Verifier(ed25519.PublicKey(make([]byte, size))); err == nil {

--- a/pkg/signature/ed25519ph.go
+++ b/pkg/signature/ed25519ph.go
@@ -109,6 +109,11 @@ func LoadED25519phVerifier(pub ed25519.PublicKey) (*ED25519phVerifier, error) {
 		return nil, errors.New("invalid ED25519 public key specified")
 	}
 
+	// check this to avoid a panic in ed25519.VerifyWithOptions and throw an error gracefully
+	if len(pub) != ed25519.PublicKeySize {
+		return nil, errors.New("invalid size for ED25519 key")
+	}
+
 	return &ED25519phVerifier{
 		publicKey: pub,
 	}, nil

--- a/pkg/signature/ed25519ph.go
+++ b/pkg/signature/ed25519ph.go
@@ -109,7 +109,6 @@ func LoadED25519phVerifier(pub ed25519.PublicKey) (*ED25519phVerifier, error) {
 		return nil, errors.New("invalid ED25519 public key specified")
 	}
 
-	// check this to avoid a panic in ed25519.VerifyWithOptions and throw an error gracefully
 	if len(pub) != ed25519.PublicKeySize {
 		return nil, errors.New("invalid size for ED25519 key")
 	}

--- a/pkg/signature/ed25519ph_test.go
+++ b/pkg/signature/ed25519ph_test.go
@@ -86,3 +86,18 @@ func TestED25519phVerifier(t *testing.T) {
 	}
 	assertPublicKeyIsx509Marshalable(t, pub)
 }
+
+// TestED25519phVerifierRejectsWrongKeySize ensures LoadED25519phVerifier validates
+// the public key length up front and returns an error, instead of accepting a
+// malformed key and letting ed25519.VerifyWithOptions panic during
+// VerifySignature. This mirrors the guard already present in LoadED25519phSigner.
+func TestED25519phVerifierRejectsWrongKeySize(t *testing.T) {
+	for _, size := range []int{0, 16, 31, 33, 64} {
+		if _, err := LoadED25519phVerifier(ed25519.PublicKey(make([]byte, size))); err == nil {
+			t.Errorf("expected error loading verifier with %d-byte key, got nil", size)
+		}
+	}
+	if _, err := LoadED25519phVerifier(ed25519.PublicKey(make([]byte, ed25519.PublicKeySize))); err != nil {
+		t.Errorf("unexpected error loading verifier with valid key size: %v", err)
+	}
+}

--- a/pkg/signature/ed25519ph_test.go
+++ b/pkg/signature/ed25519ph_test.go
@@ -87,10 +87,6 @@ func TestED25519phVerifier(t *testing.T) {
 	assertPublicKeyIsx509Marshalable(t, pub)
 }
 
-// TestED25519phVerifierRejectsWrongKeySize ensures LoadED25519phVerifier validates
-// the public key length up front and returns an error, instead of accepting a
-// malformed key and letting ed25519.VerifyWithOptions panic during
-// VerifySignature. This mirrors the guard already present in LoadED25519phSigner.
 func TestED25519phVerifierRejectsWrongKeySize(t *testing.T) {
 	for _, size := range []int{0, 16, 31, 33, 64} {
 		if _, err := LoadED25519phVerifier(ed25519.PublicKey(make([]byte, size))); err == nil {


### PR DESCRIPTION
`LoadED25519Signer` rejects a private key that isn't `ed25519.PrivateKeySize`, with the comment "check this to avoid panic and throw error gracefully". `LoadED25519Verifier` and `LoadED25519phVerifier` only check for a nil key, so a non-nil `ed25519.PublicKey` of the wrong length is accepted and the panic just moves to `VerifySignature`: crypto/ed25519's `Verify` / `VerifyWithOptions` call `panic("ed25519: bad public key length: N")`.

`LoadVerifier`, `LoadVerifierWithOpts` and `LoadUnsafeVerifier` all dispatch ed25519 keys straight to these constructors. A caller that builds a key from raw bytes, rather than going through `cryptoutils.UnmarshalPEMToPublicKey` (which always yields a 32-byte key), gets a panic at verify time instead of a load error.

This adds the same length check the signer already has, so the constructors return `invalid size for ED25519 key` up front.

Checked:
- `go test ./pkg/signature/...` passes
- the new `TestED25519VerifierRejectsWrongKeySize` / `TestED25519phVerifierRejectsWrongKeySize` fail before the change (loader returns a nil error for wrong-length keys) and pass after
