### PR TITLE
fix(oauthflow): default the device flow poll interval to 5s per RFC 8628

### DIFF
--- a/pkg/oauthflow/device.go
+++ b/pkg/oauthflow/device.go
@@ -127,6 +127,13 @@ func (d *DeviceFlowTokenGetter) deviceFlow(p *oidc.Provider, clientID, redirectU
 	if err := json.Unmarshal(b, &parsed); err != nil {
 		return "", err
 	}
+	// RFC 8628 section 3.2: interval is OPTIONAL and defaults to 5 seconds when
+	// the authorization server omits it. Without this default a missing interval
+	// leaves parsed.Interval at 0, so the authorization_pending case below sleeps
+	// for zero seconds and busy-loops the token endpoint.
+	if parsed.Interval <= 0 {
+		parsed.Interval = 5
+	}
 	uri := parsed.VerificationURIComplete
 	if uri == "" {
 		uri = parsed.VerificationURI

--- a/pkg/oauthflow/device_test.go
+++ b/pkg/oauthflow/device_test.go
@@ -170,3 +170,60 @@ func tokenResponse(idToken, err string) tokenResp {
 		Error:   err,
 	}
 }
+
+// TestDeviceFlowTokenGetter_deviceFlowDefaultInterval checks that a device
+// authorization response that omits the optional "interval" field falls back to
+// the RFC 8628 section 3.2 default of 5 seconds. Without the default, a missing
+// interval leaves it at 0 and the polling loop busy-loops the token endpoint.
+func TestDeviceFlowTokenGetter_deviceFlowDefaultInterval(t *testing.T) {
+	td := testDriver{
+		respCh: make(chan any, 3),
+		t:      t,
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(td.handler))
+	defer ts.Close()
+
+	var sleeps []time.Duration
+	dtg := DeviceFlowTokenGetter{
+		MessagePrinter: td.writeMsg,
+		Sleeper:        func(d time.Duration) { sleeps = append(sleeps, d) },
+		Issuer:         ts.URL,
+	}
+	p, pErr := oidc.NewProvider(context.Background(), ts.URL)
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	tokenCh, errCh := make(chan string), make(chan error)
+	go func() {
+		token, err := dtg.deviceFlow(p, "sigstore", "")
+		tokenCh <- token
+		errCh <- err
+	}()
+
+	// Device-code response with no "interval", then one authorization_pending
+	// (which forces the loop to sleep), then the token.
+	td.respCh <- deviceResp{
+		UserCode:                "mysecret",
+		DeviceCode:              "foobar",
+		VerificationURIComplete: "complete-uri",
+	}
+	td.respCh <- tokenResponse("", "authorization_pending")
+	td.respCh <- tokenResponse("mytoken", "")
+
+	token := <-tokenCh
+	if err := <-errCh; err != nil {
+		t.Fatal(err)
+	}
+	if token != "mytoken" {
+		t.Fatal("expected mytoken")
+	}
+
+	if len(sleeps) == 0 {
+		t.Fatal("expected the polling loop to sleep at least once")
+	}
+	if sleeps[0] != 5*time.Second {
+		t.Fatalf("expected the RFC 8628 default 5s poll interval when the server omits interval, got %s", sleeps[0])
+	}
+}


### PR DESCRIPTION
The device flow takes its poll interval straight from the authorization server's device authorization response:

```go
case "authorization_pending":
    d.Sleeper(time.Duration(parsed.Interval) * time.Second)
```

RFC 8628 section 3.2 makes `interval` optional and says clients "MUST use 5 as the default." When a provider omits it, `parsed.Interval` stays `0`, so on `authorization_pending` the loop sleeps for zero seconds and busy-polls the token endpoint.

This defaults a missing or non-positive interval to 5 seconds right after the response is parsed. The `slow_down` case still adds its extra 10 seconds on top.

Added `TestDeviceFlowTokenGetter_deviceFlowDefaultInterval`: it drives the flow with a device-code response that omits `interval` plus one `authorization_pending`, and records the sleep durations. It fails before this change (first poll sleeps `0s`) and passes after (`5s`).

Checked: `go test ./pkg/oauthflow/... -race`, `go vet ./pkg/oauthflow/...`, `gofmt -l`, `golangci-lint run ./pkg/oauthflow/...` (0 issues).
