### PR TITLE
Add BrowserOpener field to InteractiveIDTokenGetter

### DIFF
--- a/pkg/oauthflow/interactive.go
+++ b/pkg/oauthflow/interactive.go
@@ -42,6 +42,23 @@ type InteractiveIDTokenGetter struct {
 	ExtraAuthURLParams []oauth2.AuthCodeOption
 	Input              io.Reader
 	Output             io.Writer
+	// BrowserOpener, if set, is used to open the login URL in a browser during
+	// the interactive flow. It receives the authorization URL and should return
+	// an error if the browser could not be opened, in which case the flow falls
+	// back to the out-of-band flow. This allows callers to customize how (or
+	// whether) a browser is launched - for example, to select a specific
+	// browser or profile. When nil, the platform default browser is used
+	// (browser.OpenURL).
+	BrowserOpener func(url string) error
+}
+
+// openURL opens the given URL in a browser, using the configured BrowserOpener
+// if set and otherwise falling back to the package default.
+func (i *InteractiveIDTokenGetter) openURL(url string) error {
+	if i.BrowserOpener != nil {
+		return i.BrowserOpener(url)
+	}
+	return browserOpener(url)
 }
 
 // GetIDToken gets an OIDC ID Token from the specified provider using an interactive browser session
@@ -77,7 +94,7 @@ func (i *InteractiveIDTokenGetter) GetIDToken(p *oidc.Provider, cfg oauth2.Confi
 	}
 	authCodeURL := cfg.AuthCodeURL(stateToken, opts...)
 	var code string
-	if err := browserOpener(authCodeURL); err != nil {
+	if err := i.openURL(authCodeURL); err != nil {
 		// Swap to the out of band flow if we can't open the browser
 		fmt.Fprintf(i.GetOutput(), "error opening browser: %v\n", err)
 		code = i.doOobFlow(&cfg, stateToken, opts)

--- a/pkg/oauthflow/interactive_test.go
+++ b/pkg/oauthflow/interactive_test.go
@@ -16,6 +16,7 @@ package oauthflow
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"testing"
 )
@@ -42,6 +43,45 @@ func TestInteractiveFlow_IO(t *testing.T) {
 		}
 		if f.GetOutput() != b {
 			t.Error("expected buffer")
+		}
+	})
+}
+
+func TestOpenURL(t *testing.T) {
+	t.Run("custom opener", func(t *testing.T) {
+		want := errors.New("custom opener called")
+		var gotURL string
+		f := &InteractiveIDTokenGetter{
+			BrowserOpener: func(url string) error {
+				gotURL = url
+				return want
+			},
+		}
+		if err := f.openURL("https://example.com/login"); !errors.Is(err, want) {
+			t.Fatalf("expected custom opener error, got: %v", err)
+		}
+		if gotURL != "https://example.com/login" {
+			t.Errorf("custom opener got url %q, want %q", gotURL, "https://example.com/login")
+		}
+	})
+
+	t.Run("default opener", func(t *testing.T) {
+		// With no BrowserOpener configured, openURL falls back to the package
+		// default. Stub it so we don't actually launch a browser.
+		var gotURL string
+		old := browserOpener
+		browserOpener = func(url string) error {
+			gotURL = url
+			return nil
+		}
+		defer func() { browserOpener = old }()
+
+		f := &InteractiveIDTokenGetter{}
+		if err := f.openURL("https://example.com/default"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotURL != "https://example.com/default" {
+			t.Errorf("default opener got url %q, want %q", gotURL, "https://example.com/default")
 		}
 	})
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This adds a new BrowserOpener field to allow implementations to customize the browser opening experience. Existing behavior remains the same.

We want to use this in gitsign in order to allow users to provide custom browser opening commands, which allows users to force Chrome to open with certain profiles rather than relying on the default behavior of browser of "last window that happens to be open".


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Adds ability for client libraries to provide custom URL openers.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

n/a