### PR TITLE
Bump Go version to 1.27.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.25.x
+          - 1.27.x
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -80,5 +80,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.12
+          version: v2.13
           working-directory: ${{ matrix.module }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/sigstore
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/coreos/go-oidc/v3 v3.20.0

--- a/pkg/signature/ecdsa.go
+++ b/pkg/signature/ecdsa.go
@@ -187,11 +187,6 @@ func (e ECDSAVerifier) VerifySignature(signature, message io.Reader, opts ...Ver
 		return fmt.Errorf("reading signature: %w", err)
 	}
 
-	// Without this check, VerifyASN1 panics on an invalid key.
-	if !e.publicKey.IsOnCurve(e.publicKey.X, e.publicKey.Y) {
-		return fmt.Errorf("invalid ECDSA public key for %s", e.publicKey.Params().Name)
-	}
-
 	asnParseTest := struct {
 		R, S *big.Int
 	}{}

--- a/pkg/signature/ecdsa_test.go
+++ b/pkg/signature/ecdsa_test.go
@@ -23,8 +23,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
-	"fmt"
-	"math/big"
 	"strings"
 	"testing"
 
@@ -124,30 +122,35 @@ func TestECDSALoadVerifierWithoutKey(t *testing.T) {
 	}
 }
 
-// TestECDSALoadVerifierInvalidCurve tests gracefully handling an invalid curve.
-func TestECDSALoadVerifierInvalidCurve(t *testing.T) {
-	data := []byte{1}
-	x := ecdsa.PrivateKey{}
-	z := new(big.Int)
-	z.SetBytes(data)
-	x.X = z
-	x.Y = z
-	x.D = z
-	x.Curve = elliptic.P256()
-
-	verifier, err := LoadECDSAVerifier(&x.PublicKey, crypto.SHA256)
+func TestECDSAVerifySignatureFailures(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	verifier, err := LoadECDSAVerifier(&key.PublicKey, crypto.SHA256)
 	if err != nil {
 		t.Fatalf("unexpected error loading verifier: %v", err)
 	}
 
 	msg := []byte("hello")
 	digest := sha256.Sum256(msg)
-	sig, err := ecdsa.SignASN1(rand.Reader, &x, digest[:])
+
+	// Generate a valid ASN.1 signature using a different key to ensure asn1.Unmarshal succeeds and hits ecdsa.VerifyASN1
+	otherKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		fmt.Println(err)
+		t.Fatalf("unexpected error generating other key: %v", err)
+	}
+	asn1Sig, err := ecdsa.SignASN1(rand.Reader, otherKey, digest[:])
+	if err != nil {
+		t.Fatalf("unexpected error generating ASN.1 signature: %v", err)
 	}
 
-	if err := verifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err == nil || !strings.Contains(err.Error(), "invalid ECDSA public key") {
-		t.Fatalf("expected error verifying signature with invalid curve, got %v", err)
+	err = verifier.VerifySignature(bytes.NewReader(asn1Sig), bytes.NewReader(msg))
+	if err == nil || !strings.Contains(err.Error(), "validating ASN.1 encoded signature") {
+		t.Fatalf("expected ASN.1 validation error, got %v", err)
+	}
+
+	// Provide a 64-byte dummy signature that fails ASN.1 parsing and hits ecdsa.Verify (IEEE P1363 fallback)
+	ieeeSig := make([]byte, 64)
+	err = verifier.VerifySignature(bytes.NewReader(ieeeSig), bytes.NewReader(msg))
+	if err == nil || !strings.Contains(err.Error(), "validating IEEE_P1363 encoded signature") {
+		t.Fatalf("expected IEEE_P1363 validation error, got %v", err)
 	}
 }

--- a/pkg/signature/kms/aws/client.go
+++ b/pkg/signature/kms/aws/client.go
@@ -260,9 +260,9 @@ func (a *awsClient) createKey(ctx context.Context, algorithm string) (crypto.Pub
 	usage := types.KeyUsageTypeSignVerify
 	description := "Created by Sigstore"
 	key, err := a.client.CreateKey(ctx, &kms.CreateKeyInput{
-		CustomerMasterKeySpec: types.CustomerMasterKeySpec(algorithm),
-		KeyUsage:              usage,
-		Description:           &description,
+		KeySpec:     types.KeySpec(algorithm),
+		KeyUsage:    usage,
+		Description: &description,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating key: %w", err)

--- a/pkg/signature/kms/aws/go.mod
+++ b/pkg/signature/kms/aws/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/aws
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.6

--- a/pkg/signature/kms/azure/client_test.go
+++ b/pkg/signature/kms/azure/client_test.go
@@ -137,11 +137,14 @@ func generatePublicKey(azureKeyType string) (azkeys.JSONWebKey, error) {
 			return azkeys.JSONWebKey{}, fmt.Errorf("failed to cast public key to esdsa public key")
 		}
 
+		pubBytes, err := ecdsaPub.Bytes()
+		if err != nil {
+			return azkeys.JSONWebKey{}, err
+		}
+
 		curveByteSize := 32 // this assumes P256 as coded above
-		key.X = make([]byte, curveByteSize)
-		key.Y = make([]byte, curveByteSize)
-		ecdsaPub.X.FillBytes(key.X)
-		ecdsaPub.Y.FillBytes(key.Y)
+		key.X = pubBytes[1 : 1+curveByteSize]
+		key.Y = pubBytes[1+curveByteSize : 1+2*curveByteSize]
 
 		return key, nil
 	case azkeys.KeyTypeRSA, azkeys.KeyTypeRSAHSM:

--- a/pkg/signature/kms/azure/go.mod
+++ b/pkg/signature/kms/azure/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/azure
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0

--- a/pkg/signature/kms/gcp/go.mod
+++ b/pkg/signature/kms/gcp/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/gcp
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.25.0
+go 1.27.0
 
 require (
 	cloud.google.com/go/kms v1.33.0

--- a/pkg/signature/kms/hashivault/go.mod
+++ b/pkg/signature/kms/hashivault/go.mod
@@ -2,7 +2,7 @@ module github.com/sigstore/sigstore/pkg/signature/kms/hashivault
 
 replace github.com/sigstore/sigstore => ../../../../
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/hashicorp/vault/api v1.23.0

--- a/pkg/signature/tink/tink.go
+++ b/pkg/signature/tink/tink.go
@@ -20,7 +20,6 @@ import (
 	"crypto/ed25519"
 	"crypto/elliptic"
 	"fmt"
-	"math/big"
 
 	"github.com/tink-crypto/tink-go/v2/insecuresecretdataaccess"
 	"github.com/tink-crypto/tink-go/v2/keyset"
@@ -72,16 +71,7 @@ func KeyHandleToSigner(kh *keyset.Handle) (crypto.Signer, error) {
 			return nil, err
 		}
 
-		// Encoded as: 0x04 || X || Y.
-		// See https://github.com/tink-crypto/tink-go/blob/v2.3.0/signature/ecdsa/key.go#L335
-		publicPoint := ecdsaPublicKey.PublicPoint()
-		xy := publicPoint[1:]
-		pk := new(ecdsa.PrivateKey)
-		pk.Curve = curve
-		pk.X = new(big.Int).SetBytes(xy[:len(xy)/2])
-		pk.Y = new(big.Int).SetBytes(xy[len(xy)/2:])
-		pk.D = new(big.Int).SetBytes(privateKey.PrivateKeyValue().Data(insecuresecretdataaccess.Token{}))
-		return pk, err
+		return ecdsa.ParseRawPrivateKey(curve, privateKey.PrivateKeyValue().Data(insecuresecretdataaccess.Token{}))
 	case *tinked25519.PrivateKey:
 		return ed25519.NewKeyFromSeed(privateKey.PrivateKeyBytes().Data(insecuresecretdataaccess.Token{})), err
 	default:

--- a/test/cliplugin/localkms/go.mod
+++ b/test/cliplugin/localkms/go.mod
@@ -1,6 +1,6 @@
 module sigstore-kms-localkms
 
-go 1.25.0
+go 1.27.0
 
 replace github.com/sigstore/sigstore => ../../..
 


### PR DESCRIPTION
This is a prereq to #2352, to use crypto/mldsa.

This also fixes new linter failures around manual manipulation of ECDSA key parameters. There is now a method to parse a private key, and an invalid key no longer causes a panic.