### PR TITLE
Add retryable HTTP transport

### DIFF
--- a/pkg/httpretry/client.go
+++ b/pkg/httpretry/client.go
@@ -1,0 +1,284 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpretry
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultMaxRetries is the default number of times to retry a failed request.
+	DefaultMaxRetries = 4
+	// DefaultWaitMin is the default minimum time to wait between attempts.
+	DefaultWaitMin = time.Second
+	// DefaultWaitMax is the default maximum time to wait between attempts.
+	DefaultWaitMax = 30 * time.Second
+)
+
+const drainBodyLimit = 2 * 1024 * 1024
+
+// CheckRetry decides whether a response or error should be retried.
+type CheckRetry func(req *http.Request, resp *http.Response, err error) bool
+
+// Backoff decides how long to wait before the next attempt.
+type Backoff func(waitMin, waitMax time.Duration, attempt int, resp *http.Response) time.Duration
+
+// Transport is an HTTP transport that retries transient failures. A Transport
+// must not be modified after first use.
+type Transport struct {
+	// Base is the underlying transport used for each attempt. If nil,
+	// http.DefaultTransport is used.
+	Base http.RoundTripper
+	// MaxRetries is the number of times a failed request is retried.
+	MaxRetries int
+	// WaitMin is the minimum backoff between attempts.
+	WaitMin time.Duration
+	// WaitMax is the maximum backoff between attempts.
+	WaitMax time.Duration
+	// CheckRetry decides which responses and errors are retried. If nil,
+	// DefaultRetryPolicy is used.
+	CheckRetry CheckRetry
+	// Backoff decides how long to wait between retries. If nil, DefaultBackoff
+	// is used.
+	Backoff Backoff
+}
+
+// NewClient returns an HTTP client with a retrying transport.
+func NewClient() *http.Client {
+	return &http.Client{
+		Transport: NewTransport(nil),
+	}
+}
+
+// NewTransport returns a transport with the default retry settings.
+func NewTransport(base http.RoundTripper) *Transport {
+	return &Transport{
+		Base:       base,
+		MaxRetries: DefaultMaxRetries,
+		WaitMin:    DefaultWaitMin,
+		WaitMax:    DefaultWaitMax,
+		CheckRetry: DefaultRetryPolicy,
+		Backoff:    DefaultBackoff,
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req == nil {
+		return nil, errors.New("httpretry: nil request")
+	}
+
+	transport := t.Base
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	checkRetry := t.CheckRetry
+	if checkRetry == nil {
+		checkRetry = DefaultRetryPolicy
+	}
+
+	backoff := t.Backoff
+	if backoff == nil {
+		backoff = DefaultBackoff
+	}
+
+	maxRetries := max(t.MaxRetries, 0)
+	if !canReplayRequest(req) {
+		maxRetries = 0
+	}
+
+	var resp *http.Response
+	var err error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		attemptReq := req
+		if attempt > 0 {
+			attemptReq, err = cloneRequest(req)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		resp, err = transport.RoundTrip(attemptReq)
+		if !checkRetry(req, resp, err) || attempt == maxRetries {
+			return resp, err
+		}
+
+		drainAndClose(resp)
+		if err := sleep(req.Context(), backoff(t.WaitMin, t.WaitMax, attempt, resp)); err != nil {
+			return nil, err
+		}
+	}
+
+	return resp, err
+}
+
+// DefaultRetryPolicy retries connection errors, HTTP 429, and HTTP 5xx
+// responses except 501. It does not retry context cancellation, context
+// deadlines, TLS certificate errors, invalid protocol configuration, or
+// redirect-limit failures.
+func DefaultRetryPolicy(req *http.Request, resp *http.Response, err error) bool {
+	if req != nil && req.Context().Err() != nil {
+		return false
+	}
+	if err != nil {
+		return retryableError(err)
+	}
+	if resp == nil {
+		return false
+	}
+	switch {
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return true
+	case resp.StatusCode == 0:
+		return true
+	case resp.StatusCode >= http.StatusInternalServerError && resp.StatusCode != http.StatusNotImplemented:
+		return true
+	default:
+		return false
+	}
+}
+
+// DefaultBackoff returns an exponential backoff delay with jitter, capped
+// between min and max. It honors Retry-After for HTTP 429 and 503 responses
+// when present.
+func DefaultBackoff(waitMin, waitMax time.Duration, attempt int, resp *http.Response) time.Duration {
+	if waitMin <= 0 || waitMax <= 0 {
+		return 0
+	}
+	if waitMin > waitMax {
+		return waitMax
+	}
+	if retryAfter := retryAfterDelay(resp); retryAfter > 0 {
+		if retryAfter > waitMax {
+			return waitMax
+		}
+		return retryAfter
+	}
+	delay := waitMin
+	for range attempt {
+		if delay >= waitMax/2 {
+			return waitMax
+		}
+		delay *= 2
+	}
+	return jitter(waitMin, delay)
+}
+
+func retryableError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		if urlErr.Err == nil {
+			return false
+		}
+		msg := urlErr.Err.Error()
+		if strings.Contains(msg, "stopped after") && strings.Contains(msg, "redirects") {
+			return false
+		}
+		if strings.Contains(msg, "unsupported protocol scheme") || strings.Contains(msg, "invalid header") {
+			return false
+		}
+	}
+
+	var unknownAuthority x509.UnknownAuthorityError
+	var certificateInvalid x509.CertificateInvalidError
+	var hostnameError x509.HostnameError
+	return !errors.As(err, &unknownAuthority) && !errors.As(err, &certificateInvalid) && !errors.As(err, &hostnameError)
+}
+
+func retryAfterDelay(resp *http.Response) time.Duration {
+	if resp == nil || (resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != http.StatusServiceUnavailable) {
+		return 0
+	}
+	value := resp.Header.Get("Retry-After")
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds <= 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	retryTime, err := http.ParseTime(value)
+	if err != nil {
+		return 0
+	}
+	if delay := time.Until(retryTime); delay > 0 {
+		return delay
+	}
+	return 0
+}
+
+func jitter(waitMin, waitMax time.Duration) time.Duration {
+	if waitMin >= waitMax {
+		return waitMin
+	}
+	// #nosec G404 -- retry jitter only spreads load and is not used for security.
+	return waitMin + rand.N(waitMax-waitMin)
+}
+
+func canReplayRequest(req *http.Request) bool {
+	return req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+}
+
+func cloneRequest(req *http.Request) (*http.Request, error) {
+	clone := req.Clone(req.Context())
+	if req.GetBody != nil {
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, err
+		}
+		clone.Body = body
+	}
+	return clone, nil
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, drainBodyLimit))
+	_ = resp.Body.Close()
+}
+
+func sleep(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/pkg/httpretry/client_test.go
+++ b/pkg/httpretry/client_test.go
@@ -1,0 +1,312 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package httpretry
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetryServerError(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempt := attempts.Add(1)
+		if attempt < 3 {
+			http.Error(w, "try again", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	transport := NewTransport(nil)
+	transport.WaitMin = 0
+	transport.WaitMax = 0
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+	if string(body) != "ok" {
+		t.Fatalf("body = %q, want ok", body)
+	}
+}
+
+func TestNoRetryNotFound(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		http.NotFound(w, nil)
+	}))
+	defer server.Close()
+
+	transport := NewTransport(nil)
+	transport.WaitMin = 0
+	transport.WaitMax = 0
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestRetryRequestError(t *testing.T) {
+	var attempts atomic.Int32
+	transport := NewTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if attempts.Add(1) == 1 {
+			return nil, errors.New("temporary connection error")
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}))
+	transport.WaitMin = 0
+	transport.WaitMax = 0
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get("https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+}
+
+func TestNilRequest(t *testing.T) {
+	_, err := NewTransport(nil).RoundTrip(nil)
+	if err == nil {
+		t.Fatal("expected nil request error")
+	}
+}
+
+func TestCustomPolicy(t *testing.T) {
+	var attempts atomic.Int32
+	transport := NewTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Body:       io.NopCloser(strings.NewReader("try again")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}))
+	transport.MaxRetries = 1
+	transport.CheckRetry = func(_ *http.Request, _ *http.Response, _ error) bool {
+		return false
+	}
+	transport.Backoff = func(_, _ time.Duration, _ int, _ *http.Response) time.Duration {
+		t.Fatal("backoff should not be called when CheckRetry returns false")
+		return 0
+	}
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get("https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+}
+
+func TestNegativeMaxRetries(t *testing.T) {
+	var attempts atomic.Int32
+	transport := NewTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		attempts.Add(1)
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("try again")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}))
+	transport.MaxRetries = -1
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Get("https://example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+}
+
+func TestNoRetryNonReplayableBody(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
+		http.Error(w, "try again", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodPost, server.URL, io.NopCloser(strings.NewReader("body")))
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+
+	transport := NewTransport(nil)
+	transport.WaitMin = 0
+	transport.WaitMax = 0
+	client := &http.Client{Transport: transport}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if got := attempts.Load(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+}
+
+func TestDefaultRetryPolicy(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+
+	tests := []struct {
+		name string
+		resp *http.Response
+		err  error
+		want bool
+	}{
+		{
+			name: "request error",
+			err:  errors.New("temporary connection error"),
+			want: true,
+		},
+		{
+			name: "context canceled",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "deadline exceeded",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "unknown authority",
+			err:  &url.Error{Err: x509.UnknownAuthorityError{}},
+			want: false,
+		},
+		{
+			name: "invalid protocol scheme",
+			err:  &url.Error{Err: errors.New("unsupported protocol scheme \"ftp\"")},
+			want: false,
+		},
+		{
+			name: "too many redirects",
+			err:  &url.Error{Err: errors.New("stopped after 10 redirects")},
+			want: false,
+		},
+		{
+			name: "too many requests",
+			resp: &http.Response{StatusCode: http.StatusTooManyRequests},
+			want: true,
+		},
+		{
+			name: "internal server error",
+			resp: &http.Response{StatusCode: http.StatusInternalServerError},
+			want: true,
+		},
+		{
+			name: "not implemented",
+			resp: &http.Response{StatusCode: http.StatusNotImplemented},
+			want: false,
+		},
+		{
+			name: "not found",
+			resp: &http.Response{StatusCode: http.StatusNotFound},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := DefaultRetryPolicy(req, test.resp, test.err); got != test.want {
+				t.Fatalf("DefaultRetryPolicy() = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
+func TestDefaultBackoff(t *testing.T) {
+	if got := DefaultBackoff(time.Second, 30*time.Second, 2, nil); got < time.Second || got >= 4*time.Second {
+		t.Fatalf("backoff = %s, want within [1s, 4s)", got)
+	}
+
+	if got := DefaultBackoff(time.Second, 3*time.Second, 3, nil); got != 3*time.Second {
+		t.Fatalf("backoff = %s, want 3s", got)
+	}
+
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"2"}},
+	}
+	if got := DefaultBackoff(time.Second, 30*time.Second, 0, resp); got != 2*time.Second {
+		t.Fatalf("backoff = %s, want 2s", got)
+	}
+
+	resp.Header.Set("Retry-After", "60")
+	if got := DefaultBackoff(time.Second, 30*time.Second, 0, resp); got != 30*time.Second {
+		t.Fatalf("backoff = %s, want 30s", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/pkg/httpretry/doc.go
+++ b/pkg/httpretry/doc.go
@@ -1,0 +1,18 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httpretry provides retrying HTTP clients and transports for transient
+// failures.
+package httpretry


### PR DESCRIPTION
#### Summary

This adds a shared no-dependency HTTP retry package to `github.com/sigstore/sigstore` so Sigstore clients and services have a common retry transport instead of each package choosing its own third-party helper or reimplementing retry policy locally. This is related to the sigstore-go work in https://github.com/sigstore/sigstore-go/pull/671, where default TUF downloads needed retry behavior and `github.com/hashicorp/go-retryablehttp` was not the right dependency tradeoff for this codebase.

The API keeps normal `net/http` integration as the main contract. Callers can create a retrying client with `httpretry.NewClient()` or wrap an existing base transport with `httpretry.NewTransport(...)`, and the implementation remains an `http.RoundTripper` rather than a separate request execution framework. The default policy retries transient request errors, HTTP 429, status code 0, and HTTP 5xx responses except 501, while avoiding retries for context cancellation, context deadlines, TLS certificate failures, invalid protocol or header configuration, and redirect-limit failures.

The default backoff uses capped exponential delay with jitter and honors `Retry-After` for HTTP 429 and 503 responses. The transport also closes failed response bodies before retrying and avoids retrying requests with bodies that cannot be replayed, which prevents callers from accidentally resending partial or empty request data. The scope is intentionally limited to the reusable retry behavior Sigstore callers need, without adding logging hooks, custom request wrapper types, a broad client framework, or new dependencies.

#### Release Note

A shared HTTP retry package was added with a retrying transport, default retry policy, jittered backoff, `Retry-After` handling, and request replay safeguards.

#### Documentation

No documentation update is required. Callers can use this utility directly from the Go package documentation by constructing a retrying client with `httpretry.NewClient()` or wrapping an existing transport with `httpretry.NewTransport(...)`.

cc @Hayden-IO 