### PR TITLE
adjust mldsa error handling

### DIFF
--- a/pkg/cryptoutils/publickey.go
+++ b/pkg/cryptoutils/publickey.go
@@ -87,6 +87,11 @@ func MarshalPublicKeyToPEM(pub crypto.PublicKey) ([]byte, error) {
 // subjectPublicKey (excluding the tag, length, and number of unused bits).
 // https://tools.ietf.org/html/rfc5280#section-4.2.1.2
 func SKID(pub crypto.PublicKey) ([]byte, error) {
+	if mldsaKey, ok := pub.(*mldsa.PublicKey); ok {
+		if _, err := ValidateMLDSAPublicKey(mldsaKey); err != nil {
+			return nil, err
+		}
+	}
 	derPubBytes, err := x509.MarshalPKIXPublicKey(pub)
 	if err != nil {
 		return nil, err
@@ -99,7 +104,7 @@ func SKID(pub crypto.PublicKey) ([]byte, error) {
 	return skid[:], nil
 }
 
-// EqualKeys compares two public keys. Supports RSA, ECDSA and ED25519.
+// EqualKeys compares two public keys. Supports RSA, ECDSA, ED25519, and ML-DSA.
 // If not equal, the error message contains hex-encoded SHA1 hashes of the DER-encoded keys
 func EqualKeys(first, second crypto.PublicKey) error {
 	switch pub := first.(type) {
@@ -116,6 +121,9 @@ func EqualKeys(first, second crypto.PublicKey) error {
 			return errors.New(genErrMsg(first, second, "ed25519"))
 		}
 	case *mldsa.PublicKey:
+		if _, err := ValidateMLDSAPublicKey(pub); err != nil {
+			return err
+		}
 		if !pub.Equal(second) {
 			return errors.New(genErrMsg(first, second, "mldsa"))
 		}
@@ -123,6 +131,24 @@ func EqualKeys(first, second crypto.PublicKey) error {
 		return errors.New("unsupported key type")
 	}
 	return nil
+}
+
+// ValidateMLDSAPublicKey checks that the ML-DSA public key is non-nil and properly initialized,
+// returning its parameters.
+// In the Go standard library, calling methods such as Parameters() on an uninitialized
+// &mldsa.PublicKey{} panics because its internal parameters are uninitialized. This function
+// performs a deliberate probe to catch such panics safely and return a descriptive error.
+func ValidateMLDSAPublicKey(pub *mldsa.PublicKey) (params mldsa.Parameters, err error) {
+	if pub == nil {
+		return mldsa.Parameters{}, errors.New("ML-DSA public key must not be nil")
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("invalid ML-DSA public key: %v", r)
+		}
+	}()
+	// Deliberate panic probe: calling Parameters() panics if pub is &mldsa.PublicKey{}
+	return pub.Parameters(), nil
 }
 
 // genErrMsg generates an error message for EqualKeys
@@ -140,10 +166,10 @@ func genErrMsg(first, second crypto.PublicKey, keyType string) string {
 	return fmt.Sprintf("%s (%s, %s)", msg, hex.EncodeToString(firstSKID), hex.EncodeToString(secondSKID))
 }
 
-// ValidatePubKey validates the parameters of an RSA, ECDSA, or ED25519 public key.
+// ValidatePubKey validates the parameters of an RSA, ECDSA, ED25519, or ML-DSA public key.
 //
-// Deprecated: This function only verifies the size of the key for RSA or the curve
-// for ECDSA. This is largely unnecessary, and this function will be removed
+// Deprecated: This function only verifies the size of the key for RSA, the curve
+// for ECDSA, or initialization for ML-DSA. This is largely unnecessary, and this function will be removed
 // in a future version.
 func ValidatePubKey(pub crypto.PublicKey) error {
 	switch pk := pub.(type) {
@@ -161,8 +187,8 @@ func ValidatePubKey(pub crypto.PublicKey) error {
 		// Nothing to validate for Ed25519
 		return nil
 	case *mldsa.PublicKey:
-		// Nothing to validate for ML-DSA
-		return nil
+		_, err := ValidateMLDSAPublicKey(pk)
+		return err
 	}
 	return fmt.Errorf("unsupported public key type: %T", pub)
 }

--- a/pkg/cryptoutils/publickey_test.go
+++ b/pkg/cryptoutils/publickey_test.go
@@ -19,6 +19,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
+	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -71,6 +72,17 @@ func TestRSAPublicKeyPEMRoundtrip(t *testing.T) {
 	verifyPublicKeyPEMRoundtrip(t, priv.Public())
 }
 
+func TestMLDSAPublicKeyPEMRoundtrip(t *testing.T) {
+	t.Parallel()
+	for _, param := range []mldsa.Parameters{mldsa.MLDSA44(), mldsa.MLDSA65(), mldsa.MLDSA87()} {
+		priv, err := mldsa.GenerateKey(param)
+		if err != nil {
+			t.Fatalf("mldsa.GenerateKey failed: %v", err)
+		}
+		verifyPublicKeyPEMRoundtrip(t, priv.PublicKey())
+	}
+}
+
 func TestSKIDRSA(t *testing.T) {
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -113,6 +125,30 @@ func TestSKIDED25519(t *testing.T) {
 	// Expect SKID is 160 bits (20 bytes)
 	if len(skid) != 20 {
 		t.Fatalf("SKID failed: %v", skid)
+	}
+}
+
+func TestSKIDMLDSA(t *testing.T) {
+	priv, err := mldsa.GenerateKey(mldsa.MLDSA44())
+	if err != nil {
+		t.Fatalf("mldsa.GenerateKey failed: %v", err)
+	}
+	skid, err := SKID(priv.PublicKey())
+	if err != nil {
+		t.Fatalf("SKID failed for valid ML-DSA key: %v", err)
+	}
+	if len(skid) != 20 {
+		t.Fatalf("expected 20-byte SKID, got %d bytes", len(skid))
+	}
+
+	// Nil ML-DSA key
+	if _, err := SKID((*mldsa.PublicKey)(nil)); err == nil || !strings.Contains(err.Error(), "ML-DSA public key must not be nil") {
+		t.Fatalf("expected error for nil mldsa key, got %v", err)
+	}
+
+	// Empty ML-DSA key
+	if _, err := SKID(&mldsa.PublicKey{}); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA public key") {
+		t.Fatalf("expected error for empty mldsa key, got %v", err)
 	}
 }
 
@@ -162,9 +198,61 @@ func TestEqualKeys(t *testing.T) {
 	if err := EqualKeys(pubEd, pubEd2); err == nil || !strings.Contains(err.Error(), "ed25519 public keys are not equal") {
 		t.Fatalf("expected error for different ed25519 keys, got %v", err)
 	}
+	// Test ML-DSA (success and failure)
+	mldsa44First, err := mldsa.GenerateKey(mldsa.MLDSA44())
+	if err != nil {
+		t.Fatalf("mldsa.GenerateKey failed: %v", err)
+	}
+	mldsa44Second, err := mldsa.GenerateKey(mldsa.MLDSA44())
+	if err != nil {
+		t.Fatalf("mldsa.GenerateKey failed: %v", err)
+	}
+	mldsa65Key, err := mldsa.GenerateKey(mldsa.MLDSA65())
+	if err != nil {
+		t.Fatalf("mldsa.GenerateKey failed: %v", err)
+	}
+	// Verify equality with a separately constructed representation of the same key
+	mldsa44Same, err := mldsa.NewPublicKey(mldsa.MLDSA44(), mldsa44First.PublicKey().Bytes())
+	if err != nil {
+		t.Fatalf("mldsa.NewPublicKey failed: %v", err)
+	}
+	if err := EqualKeys(mldsa44First.PublicKey(), mldsa44Same); err != nil {
+		t.Fatalf("unexpected error for mldsa equality with separate representation, got %v", err)
+	}
+	if err := EqualKeys(mldsa44First.PublicKey(), mldsa44Second.PublicKey()); err == nil || !strings.Contains(err.Error(), "mldsa public keys are not equal") {
+		t.Fatalf("expected error for different mldsa keys, got %v", err)
+	}
+	if err := EqualKeys(mldsa44First.PublicKey(), mldsa65Key.PublicKey()); err == nil || !strings.Contains(err.Error(), "mldsa public keys are not equal") {
+		t.Fatalf("expected error for different mldsa parameter keys, got %v", err)
+	}
+	// Broken first argument
+	if err := EqualKeys((*mldsa.PublicKey)(nil), mldsa44First.PublicKey()); err == nil || !strings.Contains(err.Error(), "ML-DSA public key must not be nil") {
+		t.Fatalf("expected error for nil first mldsa key, got %v", err)
+	}
+	if err := EqualKeys(&mldsa.PublicKey{}, mldsa44First.PublicKey()); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA public key") {
+		t.Fatalf("expected error for empty first mldsa key, got %v", err)
+	}
+	// Broken second argument reports inequality without panicking
+	if err := EqualKeys(mldsa44First.PublicKey(), (*mldsa.PublicKey)(nil)); err == nil || !strings.Contains(err.Error(), "mldsa public keys are not equal") {
+		t.Fatalf("expected inequality error for nil second mldsa key, got %v", err)
+	}
+	if err := EqualKeys(mldsa44First.PublicKey(), &mldsa.PublicKey{}); err == nil || !strings.Contains(err.Error(), "mldsa public keys are not equal") {
+		t.Fatalf("expected inequality error for empty second mldsa key, got %v", err)
+	}
 	// Keys of different type are not equal
 	if err := EqualKeys(privRsa.Public(), pubEd); err == nil || !strings.Contains(err.Error(), "are not equal") {
-		t.Fatalf("expected error for different key types, got %v", err)
+		t.Fatalf("expected error for different key types (rsa vs ed25519), got %v", err)
+	}
+	if err := EqualKeys(mldsa44First.PublicKey(), pubEd); err == nil || !strings.Contains(err.Error(), "are not equal") {
+		t.Fatalf("expected error for different key types (mldsa vs ed25519), got %v", err)
+	}
+	// Verify that EqualKeys with a valid non-ML-DSA key and an invalid ML-DSA key exercises
+	// the SKID guard in genErrMsg without panicking.
+	if err := EqualKeys(privRsa.Public(), &mldsa.PublicKey{}); err == nil || !strings.Contains(err.Error(), "rsa public keys are not equal") {
+		t.Fatalf("expected error for rsa vs uninitialized mldsa key, got %v", err)
+	}
+	if err := EqualKeys(privRsa.Public(), (*mldsa.PublicKey)(nil)); err == nil || !strings.Contains(err.Error(), "rsa public keys are not equal") {
+		t.Fatalf("expected error for rsa vs nil mldsa key, got %v", err)
 	}
 	// Fails with unexpected key type
 	type PublicKey struct{}
@@ -233,6 +321,10 @@ func TestValidatePubKey(t *testing.T) {
 	ecdsaP384, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	ecdsaP521, _ := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 	ed25519Key, _, _ := ed25519.GenerateKey(rand.Reader)
+	mldsaPriv, err := mldsa.GenerateKey(mldsa.MLDSA44())
+	if err != nil {
+		t.Fatalf("mldsa.GenerateKey failed: %v", err)
+	}
 
 	// Invalid keys
 	rsa1024, _ := rsa.GenerateKey(rand.Reader, 1024)
@@ -273,6 +365,10 @@ func TestValidatePubKey(t *testing.T) {
 			key:  ed25519Key,
 		},
 		{
+			name: "valid mldsa",
+			key:  mldsaPriv.PublicKey(),
+		},
+		{
 			name:    "invalid rsa 1024",
 			key:     &rsa1024.PublicKey,
 			wantErr: true,
@@ -292,6 +388,16 @@ func TestValidatePubKey(t *testing.T) {
 			key:     nil,
 			wantErr: true,
 		},
+		{
+			name:    "invalid mldsa nil",
+			key:     (*mldsa.PublicKey)(nil),
+			wantErr: true,
+		},
+		{
+			name:    "invalid mldsa empty",
+			key:     &mldsa.PublicKey{},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -301,5 +407,27 @@ func TestValidatePubKey(t *testing.T) {
 				t.Errorf("ValidatePubKey() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+func TestValidateMLDSAPublicKey(t *testing.T) {
+	priv, err := mldsa.GenerateKey(mldsa.MLDSA44())
+	if err != nil {
+		t.Fatalf("mldsa.GenerateKey failed: %v", err)
+	}
+	params, err := ValidateMLDSAPublicKey(priv.PublicKey())
+	if err != nil {
+		t.Errorf("unexpected error for valid ML-DSA public key: %v", err)
+	}
+	if params != mldsa.MLDSA44() {
+		t.Errorf("expected MLDSA44 parameters, got %v", params)
+	}
+
+	if _, err := ValidateMLDSAPublicKey(nil); err == nil || !strings.Contains(err.Error(), "ML-DSA public key must not be nil") {
+		t.Errorf("expected error containing 'ML-DSA public key must not be nil', got %v", err)
+	}
+
+	if _, err := ValidateMLDSAPublicKey(&mldsa.PublicKey{}); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA public key") {
+		t.Errorf("expected error containing 'invalid ML-DSA public key', got %v", err)
 	}
 }

--- a/pkg/signature/algorithm_registry.go
+++ b/pkg/signature/algorithm_registry.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
 // PublicKeyType represents the public key algorithm for a given signature algorithm.
@@ -161,11 +162,18 @@ func (a AlgorithmDetails) checkKey(pubKey crypto.PublicKey) (bool, error) {
 		if !ok {
 			return false, nil
 		}
+		// Validate the ML-DSA key. If the key is a typed nil or uninitialized,
+		// return an error so the caller receives a meaningful diagnostic rather
+		// than a generic "unsupported algorithm" failure.
+		keyParams, err := cryptoutils.ValidateMLDSAPublicKey(mldsaKey)
+		if err != nil {
+			return false, err
+		}
 		params, err := a.GetMLDSAParameters()
 		if err != nil {
 			return false, err
 		}
-		return mldsaKey.Parameters() == params, nil
+		return keyParams == params, nil
 	}
 	return false, fmt.Errorf("unrecognized key type: %T", a.keyType)
 }
@@ -326,7 +334,11 @@ func GetDefaultPublicKeyDetails(publicKey crypto.PublicKey, opts ...LoadOption) 
 		}
 		return v1.PublicKeyDetails_PKIX_ED25519, nil
 	case *mldsa.PublicKey:
-		switch pk.Parameters() {
+		params, err := cryptoutils.ValidateMLDSAPublicKey(pk)
+		if err != nil {
+			return v1.PublicKeyDetails_PUBLIC_KEY_DETAILS_UNSPECIFIED, err
+		}
+		switch params {
 		case mldsa.MLDSA44():
 			return v1.PublicKeyDetails_ML_DSA_44, nil
 		case mldsa.MLDSA65():

--- a/pkg/signature/algorithm_registry_test.go
+++ b/pkg/signature/algorithm_registry_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/mldsa"
 	"crypto/rand"
 	"crypto/rsa"
+	"strings"
 	"testing"
 
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
@@ -401,5 +402,46 @@ func TestHashingAlgorithmMatches(t *testing.T) {
 		default:
 			t.Errorf("unrecognized hash type: %v", details.hashType)
 		}
+	}
+}
+
+func TestGetDefaultPublicKeyDetailsInvalidMLDSA(t *testing.T) {
+	keyDetails, err := GetDefaultPublicKeyDetails((*mldsa.PublicKey)(nil))
+	if err == nil || !strings.Contains(err.Error(), "ML-DSA public key must not be nil") {
+		t.Errorf("expected error containing 'ML-DSA public key must not be nil', got %v", err)
+	}
+	if keyDetails != v1.PublicKeyDetails_PUBLIC_KEY_DETAILS_UNSPECIFIED {
+		t.Errorf("expected UNSPECIFIED public key details for nil key, got %v", keyDetails)
+	}
+
+	keyDetails, err = GetDefaultPublicKeyDetails(&mldsa.PublicKey{})
+	if err == nil || !strings.Contains(err.Error(), "invalid ML-DSA public key") {
+		t.Errorf("expected error containing 'invalid ML-DSA public key', got %v", err)
+	}
+	if keyDetails != v1.PublicKeyDetails_PUBLIC_KEY_DETAILS_UNSPECIFIED {
+		t.Errorf("expected UNSPECIFIED public key details for empty key, got %v", keyDetails)
+	}
+}
+
+func TestCheckKeyInvalidMLDSA(t *testing.T) {
+	details, err := GetAlgorithmDetails(v1.PublicKeyDetails_ML_DSA_65)
+	if err != nil {
+		t.Fatalf("unexpected error getting algorithm details: %v", err)
+	}
+	// Untyped nil is not an ML-DSA key and returns (false, nil)
+	ok, err := details.checkKey(nil)
+	if err != nil || ok {
+		t.Errorf("expected (false, nil) for untyped nil key, got (%v, %v)", ok, err)
+	}
+
+	// Typed nil and uninitialized ML-DSA keys should return meaningful errors
+	ok, err = details.checkKey((*mldsa.PublicKey)(nil))
+	if err == nil || !strings.Contains(err.Error(), "ML-DSA public key must not be nil") || ok {
+		t.Errorf("expected error containing 'ML-DSA public key must not be nil', got (%v, %v)", ok, err)
+	}
+
+	ok, err = details.checkKey(&mldsa.PublicKey{})
+	if err == nil || !strings.Contains(err.Error(), "invalid ML-DSA public key") || ok {
+		t.Errorf("expected error containing 'invalid ML-DSA public key', got (%v, %v)", ok, err)
 	}
 }

--- a/pkg/signature/mldsa.go
+++ b/pkg/signature/mldsa.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
 var mldsaSupportedHashFuncs = []crypto.Hash{
@@ -35,10 +37,29 @@ type MLDSASigner struct {
 	priv *mldsa.PrivateKey
 }
 
+// validateMLDSAPrivateKey checks that the ML-DSA private key is properly initialized.
+// Calling priv.PublicKey() does not panic for an uninitialized &mldsa.PrivateKey{} in current
+// Go versions (the panic occurs when probing the resulting public key), but this recover is
+// retained as defense-in-depth against future runtime changes.
+func validateMLDSAPrivateKey(priv *mldsa.PrivateKey) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("key is invalid: %v", r)
+		}
+	}()
+	if _, valErr := cryptoutils.ValidateMLDSAPublicKey(priv.PublicKey()); valErr != nil {
+		return valErr
+	}
+	return nil
+}
+
 // LoadMLDSASigner calculates signatures using the specified private key.
 func LoadMLDSASigner(priv *mldsa.PrivateKey) (*MLDSASigner, error) {
 	if priv == nil {
 		return nil, errors.New("invalid ML-DSA private key specified")
+	}
+	if err := validateMLDSAPrivateKey(priv); err != nil {
+		return nil, fmt.Errorf("invalid ML-DSA private key specified: %w", err)
 	}
 
 	return &MLDSASigner{
@@ -46,11 +67,18 @@ func LoadMLDSASigner(priv *mldsa.PrivateKey) (*MLDSASigner, error) {
 	}, nil
 }
 
-// SignMessage signs the provided message. Passing the WithDigest option is not
-// supported as ML-DSA handles its own internal message processing.
+// SignMessage signs the provided message using Pure ML-DSA with an empty context.
 //
-// All options are ignored.
-func (m MLDSASigner) SignMessage(message io.Reader, _ ...SignOption) ([]byte, error) {
+// Passing the WithDigest option with a digest is not supported as ML-DSA handles
+// its own internal message processing. Other options are ignored.
+func (m MLDSASigner) SignMessage(message io.Reader, opts ...SignOption) ([]byte, error) {
+	var digest []byte
+	for _, opt := range opts {
+		opt.ApplyDigest(&digest)
+	}
+	if len(digest) > 0 {
+		return nil, errors.New("WithDigest is not supported for ML-DSA")
+	}
 	messageBytes, _, err := ComputeDigestForSigning(message, crypto.Hash(0), mldsaSupportedHashFuncs)
 	if err != nil {
 		return nil, err
@@ -76,11 +104,24 @@ func (m MLDSASigner) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error) {
 	return m.Public(), nil
 }
 
-// Sign computes the signature for the specified message; the first and third arguments to this
-// function are ignored as they are not used by the ML-DSA algorithm (using deterministic signing).
-func (m MLDSASigner) Sign(_ io.Reader, message []byte, _ crypto.SignerOpts) ([]byte, error) {
+// Sign computes the signature for the specified message using Pure ML-DSA with an empty context
+// for consistency across software, KMS, and hardware backends. Callers requiring domain separation
+// can enforce it at the payload level.
+//
+// The rand argument is ignored because ML-DSA internally generates randomness.
+// If opts is non-nil, only opts with an empty context and HashFunc() == crypto.Hash(0) are supported;
+// pre-hashed μ (crypto.MLDSAMu) and non-empty context strings are not permitted.
+func (m MLDSASigner) Sign(_ io.Reader, message []byte, opts crypto.SignerOpts) ([]byte, error) {
 	if message == nil {
 		return nil, errors.New("message must not be nil")
+	}
+	if opts != nil {
+		if opts.HashFunc() != crypto.Hash(0) {
+			return nil, fmt.Errorf("unsupported hash function: %v", opts.HashFunc())
+		}
+		if mldsaOpts, ok := opts.(*mldsa.Options); ok && mldsaOpts.Context != "" {
+			return nil, errors.New("non-empty context is not supported; use empty context for consistency across backends")
+		}
 	}
 	return m.SignMessage(bytes.NewReader(message))
 }
@@ -97,6 +138,9 @@ func LoadMLDSAVerifier(pub *mldsa.PublicKey) (*MLDSAVerifier, error) {
 	if pub == nil {
 		return nil, errors.New("invalid ML-DSA public key specified")
 	}
+	if _, err := cryptoutils.ValidateMLDSAPublicKey(pub); err != nil {
+		return nil, fmt.Errorf("invalid ML-DSA public key specified: %w", err)
+	}
 
 	return &MLDSAVerifier{
 		publicKey: pub,
@@ -110,19 +154,26 @@ func (m *MLDSAVerifier) PublicKey(_ ...PublicKeyOption) (crypto.PublicKey, error
 	return m.publicKey, nil
 }
 
-// VerifySignature verifies the signature for the given message.
+// VerifySignature verifies the signature for the given message using Pure ML-DSA with an empty context.
 //
 // This function returns nil if the verification succeeded, and an error message otherwise.
 //
-// All options are ignored if specified.
-func (m *MLDSAVerifier) VerifySignature(signature, message io.Reader, _ ...VerifyOption) error {
+// Passing the WithDigest option with a digest is explicitly rejected as ML-DSA does not support
+// pre-hashed message digests. Other options are ignored.
+func (m *MLDSAVerifier) VerifySignature(signature, message io.Reader, opts ...VerifyOption) error {
+	if signature == nil {
+		return errors.New("nil signature passed to VerifySignature")
+	}
+	var digest []byte
+	for _, opt := range opts {
+		opt.ApplyDigest(&digest)
+	}
+	if len(digest) > 0 {
+		return errors.New("WithDigest is not supported for ML-DSA")
+	}
 	messageBytes, _, err := ComputeDigestForVerifying(message, crypto.Hash(0), mldsaSupportedHashFuncs)
 	if err != nil {
 		return err
-	}
-
-	if signature == nil {
-		return errors.New("nil signature passed to VerifySignature")
 	}
 
 	sigBytes, err := io.ReadAll(signature)
@@ -146,11 +197,7 @@ func LoadMLDSASignerVerifier(priv *mldsa.PrivateKey) (*MLDSASignerVerifier, erro
 	if err != nil {
 		return nil, fmt.Errorf("initializing signer: %w", err)
 	}
-	pub, ok := priv.Public().(*mldsa.PublicKey)
-	if !ok {
-		return nil, fmt.Errorf("given key is not *mldsa.PublicKey")
-	}
-	verifier, err := LoadMLDSAVerifier(pub)
+	verifier, err := LoadMLDSAVerifier(priv.PublicKey())
 	if err != nil {
 		return nil, fmt.Errorf("initializing verifier: %w", err)
 	}

--- a/pkg/signature/mldsa_test.go
+++ b/pkg/signature/mldsa_test.go
@@ -18,7 +18,11 @@ package signature
 import (
 	"bytes"
 	"crypto"
+	"crypto/mldsa"
+	"strings"
 	"testing"
+
+	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 func TestMLDSASignerVerifier(t *testing.T) {
@@ -62,8 +66,8 @@ func TestMLDSASignerVerifier(t *testing.T) {
 	}
 
 	// Use the testing helpers
-	testingSigner(t, sv, "mldsa", crypto.SHA256, message)
-	testingVerifier(t, sv, "mldsa", crypto.SHA256, sig, message)
+	testingSigner(t, sv, "mldsa", crypto.Hash(0), message)
+	testingVerifier(t, sv, "mldsa", crypto.Hash(0), sig, message)
 }
 
 func TestMLDSAVerifier(t *testing.T) {
@@ -85,7 +89,7 @@ func TestMLDSAVerifier(t *testing.T) {
 		t.Fatalf("unexpected error signing message: %v", err)
 	}
 
-	testingVerifier(t, v, "mldsa", crypto.SHA256, sig, message)
+	testingVerifier(t, v, "mldsa", crypto.Hash(0), sig, message)
 
 	pub, err := v.PublicKey()
 	if err != nil {
@@ -93,5 +97,113 @@ func TestMLDSAVerifier(t *testing.T) {
 	}
 	if pub == nil {
 		t.Fatalf("expected public key, got nil")
+	}
+}
+
+func TestMLDSAInvalidKeys(t *testing.T) {
+	if _, err := LoadMLDSASigner(nil); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA private key specified") {
+		t.Errorf("expected error containing 'invalid ML-DSA private key specified' loading nil private key, got %v", err)
+	}
+	if _, err := LoadMLDSASigner(&mldsa.PrivateKey{}); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA private key specified") {
+		t.Errorf("expected error containing 'invalid ML-DSA private key specified' loading empty private key, got %v", err)
+	}
+
+	if _, err := LoadMLDSAVerifier(nil); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA public key specified") {
+		t.Errorf("expected error containing 'invalid ML-DSA public key specified' loading nil public key, got %v", err)
+	}
+	if _, err := LoadMLDSAVerifier(&mldsa.PublicKey{}); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA public key specified") {
+		t.Errorf("expected error containing 'invalid ML-DSA public key specified' loading empty public key, got %v", err)
+	}
+
+	if _, err := LoadMLDSASignerVerifier(nil); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA private key specified") {
+		t.Errorf("expected error containing 'invalid ML-DSA private key specified' loading nil private key in signer/verifier, got %v", err)
+	}
+	if _, err := LoadMLDSASignerVerifier(&mldsa.PrivateKey{}); err == nil || !strings.Contains(err.Error(), "invalid ML-DSA private key specified") {
+		t.Errorf("expected error containing 'invalid ML-DSA private key specified' loading empty private key in signer/verifier, got %v", err)
+	}
+}
+
+func TestMLDSASignerSignOptions(t *testing.T) {
+	sv, _, err := NewDefaultMLDSASignerVerifier()
+	if err != nil {
+		t.Fatalf("unexpected error creating signer: %v", err)
+	}
+
+	msg := []byte("hello world")
+
+	// Nil message should fail
+	if _, err := sv.Sign(nil, nil, nil); err == nil || !strings.Contains(err.Error(), "message must not be nil") {
+		t.Errorf("expected error containing 'message must not be nil', got %v", err)
+	}
+
+	// Nil opts should succeed
+	sig, err := sv.Sign(nil, msg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error with nil opts: %v", err)
+	}
+	if err := sv.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err != nil {
+		t.Fatalf("unexpected error verifying signature: %v", err)
+	}
+
+	// Empty context should succeed
+	sig, err = sv.Sign(nil, msg, &mldsa.Options{})
+	if err != nil {
+		t.Fatalf("unexpected error with empty context: %v", err)
+	}
+	if err := sv.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg)); err != nil {
+		t.Fatalf("unexpected error verifying signature: %v", err)
+	}
+
+	// Non-empty context should fail
+	if _, err := sv.Sign(nil, msg, &mldsa.Options{Context: "domain-sep"}); err == nil || !strings.Contains(err.Error(), "non-empty context is not supported") {
+		t.Errorf("expected error containing 'non-empty context is not supported', got %v", err)
+	}
+
+	// Unsupported hash func should fail
+	if _, err := sv.Sign(nil, msg, crypto.SHA256); err == nil || !strings.Contains(err.Error(), "unsupported hash function") {
+		t.Errorf("expected error containing 'unsupported hash function', got %v", err)
+	}
+
+	// Pre-hashed MLDSAMu should fail
+	if _, err := sv.Sign(nil, msg, crypto.MLDSAMu); err == nil || !strings.Contains(err.Error(), "unsupported hash function") {
+		t.Errorf("expected error containing 'unsupported hash function', got %v", err)
+	}
+
+	// SignMessage tests
+	if _, err := sv.SignMessage(nil); err == nil || !strings.Contains(err.Error(), "message cannot be nil") {
+		t.Errorf("expected error containing 'message cannot be nil', got %v", err)
+	}
+
+	// SignMessage with WithDigest should fail
+	if _, err := sv.SignMessage(bytes.NewReader(msg), options.WithDigest(msg)); err == nil || !strings.Contains(err.Error(), "WithDigest is not supported") {
+		t.Errorf("expected error containing 'WithDigest is not supported', got %v", err)
+	}
+}
+
+func TestMLDSAVerifierOptions(t *testing.T) {
+	sv, _, err := NewDefaultMLDSASignerVerifier()
+	if err != nil {
+		t.Fatalf("unexpected error creating signer/verifier: %v", err)
+	}
+
+	msg := []byte("hello world")
+	sig, err := sv.SignMessage(bytes.NewReader(msg))
+	if err != nil {
+		t.Fatalf("unexpected error signing message: %v", err)
+	}
+
+	// VerifySignature with nil message should fail
+	if err := sv.VerifySignature(bytes.NewReader(sig), nil); err == nil || !strings.Contains(err.Error(), "message cannot be nil") {
+		t.Errorf("expected error containing 'message cannot be nil', got %v", err)
+	}
+
+	// VerifySignature with nil signature should fail
+	if err := sv.VerifySignature(nil, bytes.NewReader(msg)); err == nil || !strings.Contains(err.Error(), "nil signature passed") {
+		t.Errorf("expected error containing 'nil signature passed', got %v", err)
+	}
+
+	// VerifySignature with WithDigest should fail
+	if err := sv.VerifySignature(bytes.NewReader(sig), bytes.NewReader(msg), options.WithDigest(msg)); err == nil || !strings.Contains(err.Error(), "WithDigest is not supported") {
+		t.Errorf("expected error containing 'WithDigest is not supported' in VerifySignature, got %v", err)
 	}
 }


### PR DESCRIPTION
Addresses review comments on ML-DSA support from #2353 that were not in #2416.

- Consolidate ML-DSA uninitialized key panic probes into a single canonical function `cryptoutils.ValidateMLDSAPublicKey`, eliminating redundant ad-hoc `recover()` blocks across `pkg/signature` and `pkg/cryptoutils`.
- Add explicit documentation on `ValidateMLDSAPublicKey` explaining the deliberate panic probe on `.Parameters()` to catch uninitialized keys where internal parameters are nil.
- Remove blanket `recover()` from `cryptoutils.SKID` and scope ML-DSA key validation explicitly.
- Restore deprecation notice on `ValidatePubKey`.
- Update `AlgorithmDetails.checkKey` to return an error on typed nil and uninitialized ML-DSA keys so callers receive clear diagnostics instead of generic mismatch errors.
- Ensure symmetric nil message and option handling between `Sign` and `SignMessage` in `pkg/signature/mldsa.go`.
- Add comprehensive tests for `SKID`, `EqualKeys` (broken first and second arguments, separate representations), `ValidateMLDSAPublicKey`, `checkKey`, `GetDefaultPublicKeyDetails`, and `SignMessage`/`Sign`/`VerifySignature` option guards.
